### PR TITLE
Fix SignatureBot to target dev and avoid history conflicts

### DIFF
--- a/.github/workflows/read-sources.yml
+++ b/.github/workflows/read-sources.yml
@@ -13,7 +13,9 @@ jobs:
   readsources:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: dev
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -118,10 +120,6 @@ jobs:
                 continue
             fi
 
-            # Add the new hash to the history file
-            echo "adding hash $new_hash to signature file" >> readsources_action.log
-            echo "$new_hash #$file" >> "baddns/signatures/signature_history.txt"
-
             # Copy the file to the signatures directory
             cp "signatures_to_test/$file" "baddns/signatures/$file"
 
@@ -167,13 +165,12 @@ jobs:
             echo "checking out new branch $BRANCH_NAME" >> readsources_action.log
             git checkout -b $BRANCH_NAME
             git add "baddns/signatures/$file"
-            git add "baddns/signatures/signature_history.txt"
             echo "about to commit with the following files changed:" >> readsources_action.log
             git status -s >> readsources_action.log
 
             echo "adding commit and pushing branch..." >> readsources_action.log
             # If the commit operation is successful, then push the changes and create a PR
-            git commit -m "[SignatureBot] Add or update signature $file and update signature history" && {
+            git commit -m "[SignatureBot] Add or update signature $file" && {
               git push origin new-signature-$file
               echo "## Add or update signature: $file" > pr_message
               echo "This PR adds or updates the follow signature:" >> pr_message
@@ -183,13 +180,14 @@ jobs:
               echo '```' >> pr_message
               echo "creating PR: '[SignatureBot] Add or update signature $file'" >> readsources_action.log
               sleep 5
-              gh pr create --title "[SignatureBot] Add or update signature $file" --body-file pr_message --head new-signature-$file --repo ${{ github.repository }} 2>&1 | tee -a readsources_action.log
+              gh pr create --base dev --title "[SignatureBot] Add or update signature $file" --body-file pr_message --head new-signature-$file --repo ${{ github.repository }} 2>&1 | tee -a readsources_action.log
             }
-            git checkout main
+            git checkout dev
           else
             echo "Skipping signature file: $file - no changes detected" >> readsources_action.log
           fi
         done
+
         echo "completed read sources" >> readsources_action.log
 
 

--- a/.github/workflows/signature-history.yml
+++ b/.github/workflows/signature-history.yml
@@ -1,0 +1,53 @@
+name: Update Signature History
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  contents: write
+
+jobs:
+  update-history:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, '[SignatureBot]')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Update signature history
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+          # Get signature files changed in the merged PR
+          CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep '^baddns/signatures/.*\.yml$' || true)
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "No signature files changed in this PR"
+            exit 0
+          fi
+
+          for file in $CHANGED_FILES; do
+            if [[ -f "$file" ]]; then
+              filename=$(basename "$file")
+              hash=$(sha256sum "$file" | cut -d ' ' -f 1)
+
+              if ! grep -q "$hash" baddns/signatures/signature_history.txt 2>/dev/null; then
+                echo "$hash #$filename" >> baddns/signatures/signature_history.txt
+                echo "Added hash for $filename"
+              fi
+            fi
+          done
+
+          if git diff --quiet baddns/signatures/signature_history.txt 2>/dev/null; then
+            echo "No new hashes to add"
+          else
+            git add baddns/signatures/signature_history.txt
+            git commit -m "[SignatureBot] Update signature history"
+            git push origin dev
+          fi


### PR DESCRIPTION
## Summary
- Checkout and branch from `dev` instead of `main` so signature PRs are based on dev
- Add `--base dev` to `gh pr create` so PRs target dev instead of main
- Stop including `signature_history.txt` in per-signature PR branches, eliminating merge conflicts when multiple signature PRs are open
- Push `signature_history.txt` updates directly to dev in a single commit after the loop

## Test plan
- [ ] Trigger workflow manually and verify PRs target dev
- [ ] Verify signature_history.txt is updated on dev, not in PR branches
- [ ] Open multiple signature PRs and confirm no conflicts