### PR TITLE
Speed up references module with WHOIS caching and concurrent domain processing

### DIFF
--- a/baddns/lib/whoismanager.py
+++ b/baddns/lib/whoismanager.py
@@ -10,9 +10,15 @@ log = logging.getLogger(__name__)
 
 
 class WhoisManager:
+    _cache = {}
+
     def __init__(self, target):
         self.target = target
         self.whois_result = None
+
+    @classmethod
+    def clear_cache(cls):
+        cls._cache.clear()
 
     async def dispatchWHOIS(self):
         ext = tldextract.extract(self.target)
@@ -26,6 +32,12 @@ class WhoisManager:
             log.debug(f"Skipping WHOIS for invalid domain [{registered_domain}] from [{self.target}]")
             self.whois_result = {"type": "error", "data": "Invalid domain for WHOIS"}
             return
+
+        if registered_domain in self._cache:
+            log.debug(f"Using cached WHOIS result for {registered_domain}")
+            self.whois_result = self._cache[registered_domain]
+            return
+
         log.debug(f"Extracted base domain [{registered_domain}] from [{self.target}]")
         log.debug(f"Submitting WHOIS query for {registered_domain}")
         try:
@@ -38,6 +50,7 @@ class WhoisManager:
         except Exception as e:
             log.debug(f"Got unknown error from whois: {str(e)}")
             self.whois_result = {"type": "error", "data": str(e)}
+        self._cache[registered_domain] = self.whois_result
 
     def analyzeWHOIS(self):
         if self.whois_result:

--- a/baddns/modules/references.py
+++ b/baddns/modules/references.py
@@ -1,4 +1,5 @@
 import re
+import asyncio
 
 from baddns.base import BadDNS_base
 from baddns.lib.dnsmanager import DNSManager
@@ -141,14 +142,10 @@ class BadDNS_references(BadDNS_base):
         log.debug(f"Completed parsing body content. Total results: {len(results)}")
         return results
 
-    async def process_cname_analysis(self, parsed_results):
-        cname_findings = []
-        for pr in parsed_results:
-            if pr["domain"] == self.target:
-                log.debug(f"Found domain matches target ({self.target}), ignoring")
-                continue
+    async def _check_single_domain(self, pr, semaphore):
+        findings = []
+        async with semaphore:
             log.debug(f"Initializing cname instance for target {pr['domain']}")
-
             for direct_mode in [True, False]:
                 cname_instance = BadDNS_cname(
                     pr["domain"],
@@ -159,15 +156,32 @@ class BadDNS_references(BadDNS_base):
                     http_client_class=self.http_client_class,
                     dns_client=self.dns_client,
                 )
-                if await cname_instance.dispatch():
-                    finding = {
-                        "finding": cname_instance.analyze(),
-                        "description": pr["description"],
-                        "trigger": pr["trigger"],
-                        "direct_mode": direct_mode,
-                    }
-                    cname_findings.append(finding)
-                await cname_instance.cleanup()
+                try:
+                    if await cname_instance.dispatch():
+                        findings.append(
+                            {
+                                "finding": cname_instance.analyze(),
+                                "description": pr["description"],
+                                "trigger": pr["trigger"],
+                                "direct_mode": direct_mode,
+                            }
+                        )
+                finally:
+                    await cname_instance.cleanup()
+        return findings
+
+    async def process_cname_analysis(self, parsed_results):
+        semaphore = asyncio.Semaphore(5)
+        tasks = []
+        for pr in parsed_results:
+            if pr["domain"] == self.target:
+                log.debug(f"Found domain matches target ({self.target}), ignoring")
+                continue
+            tasks.append(self._check_single_domain(pr, semaphore))
+        results = await asyncio.gather(*tasks)
+        cname_findings = []
+        for result in results:
+            cname_findings.extend(result)
         return cname_findings
 
     async def dispatch(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ with open(local_test_file, "r") as real_file:
 @pytest.fixture()
 def mock_dispatch_whois(request, monkeypatch):
     value = getattr(request, "param", None)
+    WhoisManager.clear_cache()
 
     async def fake_dispatch_whois(self):
         print(f"Running mock_dispatch_whois with value: [{value}]")

--- a/tests/whoismanager_extended_test.py
+++ b/tests/whoismanager_extended_test.py
@@ -5,6 +5,9 @@ from baddns.lib.whoismanager import WhoisManager
 
 
 class TestDispatchWHOIS:
+    def setup_method(self):
+        WhoisManager.clear_cache()
+
     @pytest.mark.asyncio
     async def test_generic_exception(self):
         manager = WhoisManager("example.com")

--- a/tests/whoismanager_test.py
+++ b/tests/whoismanager_test.py
@@ -7,6 +7,9 @@ from baddns.lib.whoismanager import WhoisManager
 class TestWhoisManager:
     """Test WhoisManager error handling, specifically PywhoisError"""
 
+    def setup_method(self):
+        WhoisManager.clear_cache()
+
     @pytest.mark.asyncio
     async def test_pywhois_error_handling(self):
         """Test that PywhoisError is properly caught and handled"""


### PR DESCRIPTION
## Summary
- Add class-level WHOIS cache to `WhoisManager` keyed by registered domain, eliminating redundant lookups (e.g. `seen.io` was queried 8 times for different subdomains)
- Process extracted domains concurrently in the references module using `asyncio.gather` with a semaphore (limit 5), instead of serially one at a time
- Wrap `cname_instance.cleanup()` in `finally` block so HTTP clients are always closed

## Benchmark
Tested against `janteloppet.redbull.com` (27 extracted domains from CSP/HTML):
- **Before: 1m22s**
- **After: 25s**
- ~3.3x speedup

## Test plan
- [x] All 237 tests pass
- [x] Linting clean
- [x] WHOIS cache is cleared between tests via `WhoisManager.clear_cache()` in fixtures and `setup_method`
- [x] Verified cache hits in live run (13 cache hits out of 36 lookups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)