### PR TITLE
Fix DMARC false positives on subdomains with RFC 7489 two-step lookup

### DIFF
--- a/baddns/modules/dmarc.py
+++ b/baddns/modules/dmarc.py
@@ -3,6 +3,7 @@ from baddns.lib.dnsmanager import DNSManager
 from baddns.lib.findings import Finding
 
 import logging
+import tldextract
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +19,8 @@ class BadDNS_dmarc(BadDNS_base):
             self.dmarc_target, dns_client=self.dns_client, custom_nameservers=self.custom_nameservers
         )
         self.dmarc_tags = None
+        self.org_dmarc_tags = None
+        self.is_subdomain = False
 
     @staticmethod
     def parse_dmarc_record(record):
@@ -36,6 +39,7 @@ class BadDNS_dmarc(BadDNS_base):
         return tags
 
     async def dispatch(self):
+        # Step 1: Check _dmarc.<target> (RFC 7489 Section 6.6.3)
         await self.target_dnsmanager.dispatchDNS(omit_types=["A", "AAAA", "CNAME", "NS", "SOA", "MX", "NSEC"])
         txt_records = self.target_dnsmanager.answers["TXT"]
         if txt_records:
@@ -44,12 +48,84 @@ class BadDNS_dmarc(BadDNS_base):
                 if tags is not None:
                     self.dmarc_tags = tags
                     break
+
+        # Step 2: If no record found and target is a subdomain, fall back to organizational domain
+        if self.dmarc_tags is None:
+            registered_domain = tldextract.extract(self.target).registered_domain
+            if registered_domain and registered_domain != self.target:
+                self.is_subdomain = True
+                org_dmarc_target = f"_dmarc.{registered_domain}"
+                log.debug(f"No DMARC at {self.dmarc_target}, falling back to {org_dmarc_target}")
+                org_dnsmanager = DNSManager(
+                    org_dmarc_target, dns_client=self.dns_client, custom_nameservers=self.custom_nameservers
+                )
+                await org_dnsmanager.dispatchDNS(omit_types=["A", "AAAA", "CNAME", "NS", "SOA", "MX", "NSEC"])
+                org_txt = org_dnsmanager.answers["TXT"]
+                if org_txt:
+                    for record in org_txt:
+                        tags = self.parse_dmarc_record(record)
+                        if tags is not None:
+                            self.org_dmarc_tags = tags
+                            break
         return True
+
+    def _effective_subdomain_policy(self, org_tags):
+        """Get the effective policy for a subdomain from the org domain's DMARC record.
+
+        Per RFC 7489: if sp is present, use it; otherwise subdomains inherit p.
+        """
+        return org_tags.get("sp", org_tags.get("p", "")).lower()
 
     def analyze(self):
         findings = []
 
         if self.dmarc_tags is None:
+            # Subdomain with no direct DMARC record — check if org domain covers it
+            if self.is_subdomain and self.org_dmarc_tags is not None:
+                effective_policy = self._effective_subdomain_policy(self.org_dmarc_tags)
+                if effective_policy == "none":
+                    findings.append(
+                        Finding(
+                            {
+                                "target": self.target,
+                                "description": "Subdomain inherits a DMARC policy of none from organizational domain"
+                                " - spoofed emails will be delivered",
+                                "confidence": "MODERATE",
+                                "severity": "INFORMATIONAL",
+                                "signature": "N/A",
+                                "indicator": f"Inherited policy: {effective_policy}",
+                                "trigger": self.dmarc_target,
+                                "module": type(self),
+                            }
+                        )
+                    )
+
+                pct_raw = self.org_dmarc_tags.get("pct")
+                if pct_raw is not None:
+                    try:
+                        pct = int(pct_raw)
+                        if pct < 100:
+                            findings.append(
+                                Finding(
+                                    {
+                                        "target": self.target,
+                                        "description": "Inherited DMARC policy is only partially applied",
+                                        "confidence": "MODERATE",
+                                        "severity": "INFORMATIONAL",
+                                        "signature": "N/A",
+                                        "indicator": f"pct={pct}",
+                                        "trigger": self.dmarc_target,
+                                        "module": type(self),
+                                    }
+                                )
+                            )
+                    except ValueError:
+                        log.debug(f"Invalid pct value in org DMARC record: {pct_raw}")
+
+                # Subdomain is covered by org domain — don't report "no DMARC"
+                return findings
+
+            # No DMARC anywhere
             findings.append(
                 Finding(
                     {
@@ -66,6 +142,7 @@ class BadDNS_dmarc(BadDNS_base):
             )
             return findings
 
+        # Target has its own DMARC record — analyze it directly
         p = self.dmarc_tags.get("p", "").lower()
         if p == "none":
             findings.append(

--- a/tests/dmarc_test.py
+++ b/tests/dmarc_test.py
@@ -3,10 +3,10 @@ from baddns.modules.dmarc import BadDNS_dmarc
 
 
 @pytest.mark.asyncio
-async def test_dmarc_no_txt_records(fs, configure_mock_resolver):
+async def test_dmarc_no_txt_records(configure_mock_resolver):
     mock_data = {}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -15,15 +15,15 @@ async def test_dmarc_no_txt_records(fs, configure_mock_resolver):
     assert f["indicator"] == "No DMARC record"
     assert f["confidence"] == "CONFIRMED"
     assert f["severity"] == "INFORMATIONAL"
-    assert f["trigger"] == "_dmarc.bad.dns"
+    assert f["trigger"] == "_dmarc.bad.com"
     assert f["module"] == "DMARC"
 
 
 @pytest.mark.asyncio
-async def test_dmarc_txt_exists_but_no_dmarc(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=spf1 include:example.com ~all"]}}
+async def test_dmarc_txt_exists_but_no_dmarc(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=spf1 include:example.com ~all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -32,10 +32,10 @@ async def test_dmarc_txt_exists_but_no_dmarc(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_p_none(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=none; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_p_none(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -45,10 +45,10 @@ async def test_dmarc_p_none(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_sp_none(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=reject; sp=none; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_sp_none(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; sp=none; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -58,10 +58,10 @@ async def test_dmarc_sp_none(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_pct_less_than_100(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=reject; pct=50; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_pct_less_than_100(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; pct=50; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -70,10 +70,10 @@ async def test_dmarc_pct_less_than_100(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_no_rua(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=reject"]}}
+async def test_dmarc_no_rua(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -82,10 +82,10 @@ async def test_dmarc_no_rua(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_fully_compliant(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_fully_compliant(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -93,10 +93,10 @@ async def test_dmarc_fully_compliant(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_multiple_findings_p_none_no_rua(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=none"]}}
+async def test_dmarc_multiple_findings_p_none_no_rua(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -107,10 +107,10 @@ async def test_dmarc_multiple_findings_p_none_no_rua(fs, configure_mock_resolver
 
 
 @pytest.mark.asyncio
-async def test_dmarc_all_four_issues(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=none; sp=none; pct=25"]}}
+async def test_dmarc_all_four_issues(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none; sp=none; pct=25"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -123,10 +123,10 @@ async def test_dmarc_all_four_issues(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_pct_100_no_finding(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=reject; pct=100; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_pct_100_no_finding(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; pct=100; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -134,10 +134,10 @@ async def test_dmarc_pct_100_no_finding(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_p_quarantine_no_p_none_finding(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=quarantine; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_p_quarantine_no_p_none_finding(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=quarantine; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -146,10 +146,10 @@ async def test_dmarc_p_quarantine_no_p_none_finding(fs, configure_mock_resolver)
 
 
 @pytest.mark.asyncio
-async def test_dmarc_absent_sp_no_finding(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_absent_sp_no_finding(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -158,10 +158,10 @@ async def test_dmarc_absent_sp_no_finding(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_case_insensitivity(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["V=DMARC1; P=None; RUA=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_case_insensitivity(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["V=DMARC1; P=None; RUA=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
@@ -170,12 +170,122 @@ async def test_dmarc_case_insensitivity(fs, configure_mock_resolver):
 
 
 @pytest.mark.asyncio
-async def test_dmarc_invalid_pct_no_crash(fs, configure_mock_resolver):
-    mock_data = {"_dmarc.bad.dns": {"TXT": ["v=DMARC1; p=reject; pct=abc; rua=mailto:dmarc@bad.dns"]}}
+async def test_dmarc_invalid_pct_no_crash(configure_mock_resolver):
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; pct=abc; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
-    target = "bad.dns"
+    target = "bad.com"
     m = BadDNS_dmarc(target, dns_client=mock_resolver)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
     assert not any(i.startswith("pct=") for i in indicators)
+
+
+# --- Subdomain inheritance tests (RFC 7489 Section 6.6.3) ---
+
+
+@pytest.mark.asyncio
+async def test_dmarc_subdomain_inherits_reject(configure_mock_resolver):
+    """Subdomain has no DMARC, but org domain has p=reject. Subdomain is protected."""
+    mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "sub.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    assert len(findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_dmarc_subdomain_inherits_sp_none(configure_mock_resolver):
+    """Org domain has p=reject but sp=none. Subdomain is NOT protected."""
+    mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; sp=none; rua=mailto:dmarc@example.com"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "sub.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    assert len(findings) == 1
+    f = findings[0].to_dict()
+    assert "Inherited policy: none" in f["indicator"]
+
+
+@pytest.mark.asyncio
+async def test_dmarc_subdomain_inherits_p_none(configure_mock_resolver):
+    """Org domain has p=none (no sp). Subdomain inherits p=none — not protected."""
+    mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=none; rua=mailto:dmarc@example.com"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "sub.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    indicators = [f.to_dict()["indicator"] for f in findings]
+    assert "Inherited policy: none" in indicators
+
+
+@pytest.mark.asyncio
+async def test_dmarc_subdomain_no_org_record(configure_mock_resolver):
+    """Subdomain has no DMARC and org domain has no DMARC either. Report missing."""
+    mock_data = {}
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "sub.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    assert len(findings) == 1
+    assert findings[0].to_dict()["indicator"] == "No DMARC record"
+
+
+@pytest.mark.asyncio
+async def test_dmarc_subdomain_own_record_overrides(configure_mock_resolver):
+    """Subdomain has its own DMARC record — should use it, not fall back to org."""
+    mock_data = {
+        "_dmarc.sub.example.com": {"TXT": ["v=DMARC1; p=none; rua=mailto:dmarc@example.com"]},
+        "_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "sub.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    indicators = [f.to_dict()["indicator"] for f in findings]
+    assert "p=none" in indicators
+    assert "No DMARC record" not in indicators
+
+
+@pytest.mark.asyncio
+async def test_dmarc_subdomain_inherits_sp_quarantine(configure_mock_resolver):
+    """Org domain has sp=quarantine. Subdomain is protected."""
+    mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; sp=quarantine; rua=mailto:dmarc@example.com"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "sub.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    assert len(findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_dmarc_subdomain_inherits_low_pct(configure_mock_resolver):
+    """Org domain has p=reject but pct=25. Subdomain inherits the partial application."""
+    mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; pct=25; rua=mailto:dmarc@example.com"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "sub.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    indicators = [f.to_dict()["indicator"] for f in findings]
+    assert "pct=25" in indicators
+    assert "No DMARC record" not in indicators
+
+
+@pytest.mark.asyncio
+async def test_dmarc_deep_subdomain_inherits(configure_mock_resolver):
+    """Deep subdomain (a.b.example.com) falls back to _dmarc.example.com per RFC 7489."""
+    mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    target = "a.b.example.com"
+    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    assert await m.dispatch()
+    findings = m.analyze()
+    assert len(findings) == 0


### PR DESCRIPTION
## Summary
- Implement RFC 7489 Section 6.6.3 two-step DMARC lookup: when a subdomain has no DMARC record, fall back to `_dmarc.<organizational domain>` before reporting missing DMARC
- Use `tldextract` to correctly determine the organizational domain (handles complex TLDs like `.co.uk`)
- When a subdomain inherits from the org domain, evaluate the effective subdomain policy (`sp` if present, otherwise `p`) and only report findings when the inherited policy is weak
- Remove unnecessary `fs` (pyfakefs) fixture from DMARC tests and use real TLD domains

## Problem
The DMARC module was firing on nearly every subdomain because it only checked `_dmarc.<target>`. Per RFC 7489, subdomains inherit DMARC policy from their organizational domain — a subdomain not having its own DMARC record is completely normal.

## Inheritance behavior
- `p=reject` (no `sp`) → subdomains inherit `reject` → no finding
- `p=reject; sp=quarantine` → subdomains get `quarantine` → no finding
- `p=reject; sp=none` → subdomains get `none` → finding reported
- `p=none` (no `sp`) → subdomains inherit `none` → finding reported
- No org DMARC at all → finding reported

## Test plan
- [x] All 245 tests pass (14 existing + 8 new subdomain inheritance tests)
- [x] Linting clean
- [x] Deep subdomains (`a.b.example.com`) correctly fall back to org domain
- [x] Subdomain's own DMARC record takes priority over org domain's

🤖 Generated with [Claude Code](https://claude.com/claude-code)