### PR TITLE
Skip DNS targets with labels exceeding 63-octet RFC 1035 limit

### DIFF
--- a/baddns/lib/dnswalk.py
+++ b/baddns/lib/dnswalk.py
@@ -47,6 +47,10 @@ class DnsWalk:
 
     async def ns_trace(self, target):
         log.debug(f"Attempting to find NS records for {target}")
+        for label in target.split("."):
+            if len(label) > 63:
+                log.debug(f"Skipping target [{target}]: label [{label}] exceeds 63-octet RFC 1035 limit")
+                return []
         nameserver_ips = self.root_servers[:]
         solved_nameservers = await self.ns_recursive_solve(nameserver_ips, target, depth=0)
         if solved_nameservers == None:

--- a/tests/ns_test.py
+++ b/tests/ns_test.py
@@ -65,3 +65,20 @@ async def test_ns_nosoa_generic(fs, configure_mock_resolver):
         "module": "NS",
     }
     assert any(expected == finding.to_dict() for finding in findings)
+
+
+@pytest.mark.asyncio
+async def test_ns_label_too_long(fs, configure_mock_resolver):
+    mock_data = {}
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "a" * 64 + ".bad.dns"
+    mock_signature_load(fs, "dnsreaper_wordpress_com_ns.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_ns = BadDNS_ns(target, signatures=signatures, dns_client=mock_resolver)
+
+    findings = None
+    if await baddns_ns.dispatch():
+        findings = baddns_ns.analyze()
+
+    assert not findings


### PR DESCRIPTION
## Summary
- Fixes #474
- Validates DNS labels in `DnsWalk.ns_trace()` before starting recursive resolution — targets with labels > 63 octets are skipped with a debug log message
- Prevents unhandled `dns.name.LabelTooLong` exception from dnspython

## Test plan
- [x] Added `test_ns_label_too_long` to verify early bail on invalid targets
- [x] Existing NS tests still pass