### PR TITLE
Add wildcard DNS detection module

### DIFF
--- a/baddns/modules/wildcard.py
+++ b/baddns/modules/wildcard.py
@@ -1,0 +1,145 @@
+import uuid
+import logging
+
+from baddns.base import BadDNS_base
+from baddns.lib.dnsmanager import DNSManager
+from baddns.lib.httpmanager import HttpManager
+from baddns.modules.cname import BadDNS_cname
+from baddns.lib.findings import Finding
+
+log = logging.getLogger(__name__)
+
+
+class BadDNS_wildcard(BadDNS_base):
+    name = "WILDCARD"
+    description = "Check for wildcard DNS records that could enable domain-wide subdomain takeover"
+
+    def __init__(self, target, **kwargs):
+        super().__init__(target, **kwargs)
+        self.target = target
+        self.target_dnsmanager = DNSManager(
+            target, dns_client=self.dns_client, custom_nameservers=self.custom_nameservers
+        )
+        self.target_httpmanager = HttpManager(
+            self.target, http_client_class=self.http_client_class, skip_redirects=True
+        )
+        self.cname_findings = None
+        self.cname_findings_direct = None
+        self.parent_domain = None
+
+    @staticmethod
+    def _generate_random_label():
+        return f"baddns-{uuid.uuid4().hex[:8]}"
+
+    def _get_parent_domain(self):
+        parts = self.target.split(".")
+        if len(parts) < 3:
+            return None
+        return ".".join(parts[1:])
+
+    async def dispatch(self):
+        self.cname_findings_direct = []
+        self.cname_findings = []
+
+        self.parent_domain = self._get_parent_domain()
+        if self.parent_domain is None:
+            log.debug(f"Target {self.target} has no suitable parent domain for wildcard check, skipping")
+            return False
+
+        random_label = self._generate_random_label()
+        probe_target = f"{random_label}.{self.parent_domain}"
+        log.debug(f"Probing wildcard with random subdomain: {probe_target}")
+
+        probe_dnsmanager = DNSManager(
+            probe_target, dns_client=self.dns_client, custom_nameservers=self.custom_nameservers
+        )
+        await probe_dnsmanager.dispatchDNS(omit_types=["MX", "NS", "SOA", "TXT", "NSEC"])
+
+        if probe_dnsmanager.answers["NXDOMAIN"]:
+            log.debug(f"No wildcard DNS record found for *.{self.parent_domain}")
+            return False
+
+        if not probe_dnsmanager.answers["CNAME"]:
+            log.debug(f"Wildcard exists for *.{self.parent_domain} but has no CNAME (A/AAAA only), skipping")
+            return False
+
+        wildcard_cname = probe_dnsmanager.answers["CNAME"][-1]
+        self.infomsg(f"Wildcard CNAME detected: *.{self.parent_domain} -> {wildcard_cname}")
+
+        cname_instance_direct = BadDNS_cname(
+            wildcard_cname,
+            custom_nameservers=self.custom_nameservers,
+            signatures=self.signatures,
+            direct_mode=True,
+            parent_class="wildcard",
+            http_client_class=self.http_client_class,
+            dns_client=self.dns_client,
+        )
+        if await cname_instance_direct.dispatch():
+            self.cname_findings_direct.append(
+                {
+                    "finding": cname_instance_direct.analyze(),
+                    "description": f"Wildcard CNAME detected at *.{self.parent_domain}. ALL subdomains of {self.parent_domain} are affected",
+                    "trigger": f"*.{self.parent_domain}",
+                }
+            )
+        await cname_instance_direct.cleanup()
+
+        # Use the probe target (not the CNAME target) so the CNAME module
+        # discovers the chain naturally and can detect generic dangling CNAMEs
+        cname_instance = BadDNS_cname(
+            probe_target,
+            custom_nameservers=self.custom_nameservers,
+            signatures=self.signatures,
+            direct_mode=False,
+            parent_class="wildcard",
+            http_client_class=self.http_client_class,
+            dns_client=self.dns_client,
+        )
+        if await cname_instance.dispatch():
+            self.cname_findings.append(
+                {
+                    "finding": cname_instance.analyze(),
+                    "description": f"Wildcard CNAME detected at *.{self.parent_domain}. ALL subdomains of {self.parent_domain} are affected",
+                    "trigger": f"*.{self.parent_domain}",
+                }
+            )
+        await cname_instance.cleanup()
+
+        return True
+
+    def _convert_findings(self, finding_sets):
+        converted_findings = []
+        for finding_set in finding_sets:
+            for finding in finding_set["finding"]:
+                finding_dict = finding.to_dict()
+                log.debug(f"Found finding during wildcard cname check for target: {finding_dict['target']}")
+                converted_findings.append(
+                    Finding(
+                        {
+                            "target": self.target,
+                            "description": f"{finding_set['description']}. Original Event: [{finding_dict['description']}]",
+                            "confidence": finding_dict["confidence"],
+                            "severity": "HIGH",
+                            "signature": finding_dict["signature"],
+                            "indicator": finding_dict["indicator"],
+                            "trigger": finding_set["trigger"],
+                            "module": type(self),
+                        }
+                    )
+                )
+        return converted_findings
+
+    def analyze(self):
+        findings = []
+        log.debug("in wildcard analyze")
+        if self.cname_findings_direct:
+            findings.extend(self._convert_findings(self.cname_findings_direct))
+        if self.cname_findings:
+            findings.extend(self._convert_findings(self.cname_findings))
+        return findings
+
+    async def cleanup(self):
+        if self.target_httpmanager:
+            await self.target_httpmanager.close()
+            log.debug("HTTP Manager cleaned up successfully.")

--- a/tests/wildcard_test.py
+++ b/tests/wildcard_test.py
@@ -1,0 +1,218 @@
+import functools
+import pytest
+import requests
+import ssl
+from baddns.modules.wildcard import BadDNS_wildcard
+from baddns.lib.loader import load_signatures
+from .helpers import mock_signature_load
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+requests.adapters.BaseAdapter.send = functools.partialmethod(requests.adapters.BaseAdapter.send, verify=False)
+requests.adapters.HTTPAdapter.send = functools.partialmethod(requests.adapters.HTTPAdapter.send, verify=False)
+requests.Session.request = functools.partialmethod(requests.Session.request, verify=False)
+requests.request = functools.partial(requests.request, verify=False)
+
+
+@pytest.fixture(autouse=True)
+def patch_random_label(monkeypatch):
+    monkeypatch.setattr(BadDNS_wildcard, "_generate_random_label", staticmethod(lambda: "baddns-test1234"))
+
+
+@pytest.mark.asyncio
+async def test_wildcard_cname_nxdomain_signature_match(fs, mock_dispatch_whois, configure_mock_resolver):
+    """Wildcard CNAME to NXDOMAIN service with signature match -> HIGH severity finding."""
+    mock_data = {
+        "baddns-test1234.bad.dns": {"CNAME": ["baddns.azurewebsites.net."]},
+        "_NXDOMAIN": ["baddns.azurewebsites.net"],
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "sub.bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    findings = None
+    if await baddns_wildcard.dispatch():
+        findings = baddns_wildcard.analyze()
+
+    assert findings
+    expected = {
+        "target": "sub.bad.dns",
+        "description": "Wildcard CNAME detected at *.bad.dns. ALL subdomains of bad.dns are affected. Original Event: [Dangling CNAME, probable subdomain takeover (NXDOMAIN technique)]",
+        "confidence": "HIGH",
+        "severity": "HIGH",
+        "signature": "Microsoft Azure Takeover Detection",
+        "indicator": "azurewebsites.net",
+        "trigger": "*.bad.dns",
+        "module": "WILDCARD",
+    }
+    assert any(expected == finding.to_dict() for finding in findings)
+
+
+@pytest.mark.asyncio
+async def test_wildcard_no_wildcard_nxdomain(fs, mock_dispatch_whois, configure_mock_resolver):
+    """No wildcard record (NXDOMAIN for random subdomain) -> dispatch returns False."""
+    mock_data = {
+        "_NXDOMAIN": ["baddns-test1234.bad.dns"],
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "sub.bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    result = await baddns_wildcard.dispatch()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_wildcard_a_record_only(fs, mock_dispatch_whois, configure_mock_resolver):
+    """Wildcard resolves to A record only (no CNAME) -> dispatch returns False."""
+    mock_data = {
+        "baddns-test1234.bad.dns": {"A": ["1.2.3.4"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "sub.bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    result = await baddns_wildcard.dispatch()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_wildcard_target_is_registered_domain(fs, mock_dispatch_whois, configure_mock_resolver):
+    """Target is already a registered domain (e.g. bad.dns) -> dispatch returns False."""
+    mock_data = {}
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    result = await baddns_wildcard.dispatch()
+    assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+async def test_wildcard_cname_resolves_not_vulnerable(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """Wildcard CNAME resolves to a healthy target -> no findings."""
+    mock_data = {
+        "baddns-test1234.bad.dns": {"CNAME": ["healthy.example.com."]},
+        "healthy.example.com": {"A": ["1.2.3.4"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "sub.bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    findings = None
+    if await baddns_wildcard.dispatch():
+        findings = baddns_wildcard.analyze()
+
+    assert not findings
+
+
+@pytest.mark.asyncio
+async def test_wildcard_deep_subdomain(fs, mock_dispatch_whois, configure_mock_resolver):
+    """Deep subdomain (deep.sub.bad.dns) checks *.sub.bad.dns."""
+    mock_data = {
+        "baddns-test1234.sub.bad.dns": {"CNAME": ["baddns.azurewebsites.net."]},
+        "_NXDOMAIN": ["baddns.azurewebsites.net"],
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "deep.sub.bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    findings = None
+    if await baddns_wildcard.dispatch():
+        findings = baddns_wildcard.analyze()
+
+    assert findings
+    expected = {
+        "target": "deep.sub.bad.dns",
+        "description": "Wildcard CNAME detected at *.sub.bad.dns. ALL subdomains of sub.bad.dns are affected. Original Event: [Dangling CNAME, probable subdomain takeover (NXDOMAIN technique)]",
+        "confidence": "HIGH",
+        "severity": "HIGH",
+        "signature": "Microsoft Azure Takeover Detection",
+        "indicator": "azurewebsites.net",
+        "trigger": "*.sub.bad.dns",
+        "module": "WILDCARD",
+    }
+    assert any(expected == finding.to_dict() for finding in findings)
+
+
+mock_whois_unregistered = {
+    "type": "error",
+    "data": 'No match for "WORSE.DNS".\r\n>>> Last update of whois database: 2023-08-17T14:07:31Z <<<\r\n',
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+@pytest.mark.parametrize("mock_dispatch_whois", [mock_whois_unregistered], indirect=True)
+async def test_wildcard_whois_unregistered(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """Wildcard CNAME to a domain that is unregistered per WHOIS -> CONFIRMED confidence."""
+    mock_data = {
+        "baddns-test1234.bad.dns": {"CNAME": ["worse.dns."]},
+        "worse.dns": {"A": ["127.0.0.2"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "sub.bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    findings = None
+    if await baddns_wildcard.dispatch():
+        findings = baddns_wildcard.analyze()
+
+    assert findings
+    assert any(f.to_dict()["confidence"] == "CONFIRMED" for f in findings)
+    assert any(f.to_dict()["severity"] == "HIGH" for f in findings)
+    assert any(f.to_dict()["module"] == "WILDCARD" for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_wildcard_generic_dangling_cname(fs, mock_dispatch_whois, configure_mock_resolver):
+    """Wildcard CNAME to unknown NXDOMAIN service (no signature) -> MODERATE confidence, GENERIC."""
+    mock_data = {
+        "baddns-test1234.bad.dns": {"CNAME": ["unknown.randomthing.net."]},
+        "_NXDOMAIN": ["unknown.randomthing.net"],
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    target = "sub.bad.dns"
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_wildcard = BadDNS_wildcard(target, signatures=signatures, dns_client=mock_resolver)
+
+    findings = None
+    if await baddns_wildcard.dispatch():
+        findings = baddns_wildcard.analyze()
+
+    assert findings
+    expected = {
+        "target": "sub.bad.dns",
+        "description": "Wildcard CNAME detected at *.bad.dns. ALL subdomains of bad.dns are affected. Original Event: [Dangling CNAME, possible subdomain takeover (NXDOMAIN technique)]",
+        "confidence": "MODERATE",
+        "severity": "HIGH",
+        "signature": "GENERIC",
+        "indicator": "Generic Dangling CNAME",
+        "trigger": "*.bad.dns",
+        "module": "WILDCARD",
+    }
+    assert any(expected == finding.to_dict() for finding in findings)


### PR DESCRIPTION
## Summary
- Adds new `WILDCARD` module that detects wildcard DNS CNAME records (`*.parent.com`) pointing to vulnerable third-party services
- Probes a random subdomain (`baddns-<uuid>.parent.com`) to detect wildcard records, then delegates to the CNAME module for takeover analysis
- Elevates severity to HIGH since wildcard takeovers affect all subdomains of the parent domain
- Includes 8 tests covering signature match, NXDOMAIN, A-only wildcard, registered domain skip, healthy CNAME, deep subdomains, WHOIS unregistered, and generic dangling CNAME

## Test plan
- [x] `poetry run pytest tests/wildcard_test.py -v` — all 8 tests pass
- [x] `ruff format --check .` and `ruff check .` — clean
- [x] `poetry run pytest --exitfirst --disable-warnings` — full suite (254 tests) passes with no regressions