### PR TITLE
Add MTA-STS module

### DIFF
--- a/baddns/modules/mtasts.py
+++ b/baddns/modules/mtasts.py
@@ -1,0 +1,257 @@
+import httpx
+import logging
+import fnmatch
+
+from baddns.base import BadDNS_base
+from baddns.lib.dnsmanager import DNSManager
+from baddns.lib.whoismanager import WhoisManager
+from baddns.lib.findings import Finding
+from baddns.modules.cname import BadDNS_cname
+
+log = logging.getLogger(__name__)
+
+
+class BadDNS_mtasts(BadDNS_base):
+    name = "MTA-STS"
+    description = "Check for MTA-STS misconfigurations and dangling mta-sts subdomains"
+
+    def __init__(self, target, **kwargs):
+        super().__init__(target, **kwargs)
+        self.target = target
+
+        self.target_dnsmanager = DNSManager(
+            f"_mta-sts.{target}", dns_client=self.dns_client, custom_nameservers=self.custom_nameservers
+        )
+        self.mx_dnsmanager = DNSManager(target, dns_client=self.dns_client, custom_nameservers=self.custom_nameservers)
+
+        self.sts_id = None
+        self.cname_findings_direct = []
+        self.cname_findings = []
+        self.policy = None
+        self.policy_error = None
+        self.mx_whois_results = {}
+        self.mta_sts_host = f"mta-sts.{target}"
+
+        http_client_class = self.http_client_class or httpx.AsyncClient
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:117.0) Gecko/20100101 Firefox/117.0",
+        }
+        self._policy_client = http_client_class(timeout=5, verify=False, headers=headers)
+
+    async def dispatch(self):
+        # Step 1: Check for _mta-sts TXT record
+        await self.target_dnsmanager.dispatchDNS(omit_types=["A", "AAAA", "CNAME", "NS", "SOA", "MX", "NSEC"])
+        if self.target_dnsmanager.answers["TXT"] is None:
+            log.debug("No _mta-sts TXT record found, aborting")
+            return False
+
+        # Parse for v=STSv1
+        found_sts = False
+        for txt_record in self.target_dnsmanager.answers["TXT"]:
+            if "v=STSv1" in txt_record:
+                found_sts = True
+                # Extract id
+                for part in txt_record.replace(" ", "").split(";"):
+                    if part.startswith("id="):
+                        self.sts_id = part[3:]
+                break
+
+        if not found_sts:
+            log.debug("No v=STSv1 TXT record found, aborting")
+            return False
+
+        self.infomsg(f"Found MTA-STS TXT record for {self.target} (id={self.sts_id})")
+
+        # Step 2: Delegate mta-sts.<target> to CNAME module (both direct and non-direct mode)
+        cname_instance_direct = BadDNS_cname(
+            self.mta_sts_host,
+            custom_nameservers=self.custom_nameservers,
+            signatures=self.signatures,
+            direct_mode=True,
+            parent_class="mtasts",
+            http_client_class=self.http_client_class,
+            dns_client=self.dns_client,
+        )
+        if await cname_instance_direct.dispatch():
+            direct_results = cname_instance_direct.analyze()
+            if direct_results:
+                self.cname_findings_direct.append(
+                    {
+                        "finding": direct_results,
+                        "description": f"Dangling mta-sts subdomain [{self.mta_sts_host}]",
+                        "trigger": self.target,
+                    }
+                )
+        await cname_instance_direct.cleanup()
+
+        cname_instance = BadDNS_cname(
+            self.mta_sts_host,
+            custom_nameservers=self.custom_nameservers,
+            signatures=self.signatures,
+            direct_mode=False,
+            parent_class="mtasts",
+            http_client_class=self.http_client_class,
+            dns_client=self.dns_client,
+        )
+        if await cname_instance.dispatch():
+            cname_results = cname_instance.analyze()
+            if cname_results:
+                self.cname_findings.append(
+                    {
+                        "finding": cname_results,
+                        "description": f"Dangling mta-sts subdomain [{self.mta_sts_host}]",
+                        "trigger": self.target,
+                    }
+                )
+        await cname_instance.cleanup()
+
+        # Step 3: Fetch policy file
+        policy_url = f"https://{self.mta_sts_host}/.well-known/mta-sts.txt"
+        try:
+            response = await self._policy_client.get(policy_url, follow_redirects=True)
+            if response.status_code == 200:
+                self.policy = self._parse_policy(response.text)
+                log.debug(f"Parsed MTA-STS policy: {self.policy}")
+            else:
+                self.policy_error = f"HTTP {response.status_code}"
+                log.debug(f"Policy fetch returned {response.status_code}")
+        except Exception as e:
+            self.policy_error = str(e)
+            log.debug(f"Policy fetch failed: {e}")
+
+        # Step 4: Query actual MX records
+        await self.mx_dnsmanager.dispatchDNS(omit_types=["A", "AAAA", "CNAME", "NS", "SOA", "TXT", "NSEC"])
+
+        # Step 5: WHOIS check on non-wildcard mx domains in policy
+        if self.policy and self.policy.get("mx"):
+            for mx_entry in self.policy["mx"]:
+                if mx_entry.startswith("*."):
+                    continue
+                whois_mgr = WhoisManager(mx_entry)
+                await whois_mgr.dispatchWHOIS()
+                self.mx_whois_results[mx_entry] = whois_mgr
+
+        return True
+
+    @staticmethod
+    def _parse_policy(text):
+        policy = {"version": None, "mode": None, "max_age": None, "mx": []}
+        for line in text.strip().splitlines():
+            line = line.strip()
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            key = key.strip().lower()
+            value = value.strip()
+            if key == "version":
+                policy["version"] = value
+            elif key == "mode":
+                policy["mode"] = value
+            elif key == "max_age":
+                policy["max_age"] = value
+            elif key == "mx":
+                policy["mx"].append(value)
+        return policy
+
+    def _mx_matches(self, policy_mx_pattern, actual_mx):
+        """Check if an actual MX hostname matches a policy mx pattern (supports wildcards)."""
+        return fnmatch.fnmatch(actual_mx.lower(), policy_mx_pattern.lower())
+
+    def _convert_cname_findings(self, finding_sets):
+        converted = []
+        for finding_set in finding_sets:
+            for finding in finding_set["finding"]:
+                finding_dict = finding.to_dict()
+                log.debug(f"Found finding during cname check for mta-sts host: {finding_dict['target']}")
+                converted.append(
+                    Finding(
+                        {
+                            "target": self.target,
+                            "description": f"{finding_set['description']}. Original Event: [{finding_dict['description']}]",
+                            "confidence": finding_dict["confidence"],
+                            "severity": "HIGH",
+                            "signature": finding_dict["signature"],
+                            "indicator": finding_dict["indicator"],
+                            "trigger": finding_set["trigger"],
+                            "module": type(self),
+                        }
+                    )
+                )
+        return converted
+
+    def analyze(self):
+        findings = []
+
+        # Finding 1: Dangling mta-sts subdomain via CNAME delegation
+        if self.cname_findings_direct:
+            findings.extend(self._convert_cname_findings(self.cname_findings_direct))
+        if self.cname_findings:
+            findings.extend(self._convert_cname_findings(self.cname_findings))
+
+        # Finding 2: Orphaned TXT record with unreachable policy
+        if self.policy_error and not self.cname_findings_direct and not self.cname_findings:
+            findings.append(
+                Finding(
+                    {
+                        "target": self.target,
+                        "description": f"Orphaned MTA-STS TXT record: _mta-sts.{self.target} exists but policy is unreachable ({self.policy_error})",
+                        "confidence": "MODERATE",
+                        "severity": "MEDIUM",
+                        "signature": "N/A",
+                        "indicator": "MTA-STS Policy Unreachable",
+                        "trigger": f"_mta-sts.{self.target}",
+                        "module": type(self),
+                    }
+                )
+            )
+
+        if self.policy:
+            actual_mx = self.mx_dnsmanager.answers.get("MX") or []
+
+            # Finding 3: Policy MX mismatch (only in enforce mode)
+            if self.policy.get("mode") == "enforce" and actual_mx:
+                unmatched = []
+                for mx_host in actual_mx:
+                    if not any(self._mx_matches(pattern, mx_host) for pattern in self.policy["mx"]):
+                        unmatched.append(mx_host)
+                if unmatched:
+                    findings.append(
+                        Finding(
+                            {
+                                "target": self.target,
+                                "description": f"MTA-STS policy MX mismatch in enforce mode: actual MX records [{', '.join(unmatched)}] not covered by policy mx lines",
+                                "confidence": "MODERATE",
+                                "severity": "MEDIUM",
+                                "signature": "N/A",
+                                "indicator": "MTA-STS MX Mismatch",
+                                "trigger": f"_mta-sts.{self.target}",
+                                "module": type(self),
+                            }
+                        )
+                    )
+
+            # Finding 4: Dangling domains in policy mx lines (WHOIS)
+            for mx_entry, whois_mgr in self.mx_whois_results.items():
+                if whois_mgr.whois_result:
+                    for whois_finding in whois_mgr.analyzeWHOIS():
+                        findings.append(
+                            Finding(
+                                {
+                                    "target": self.target,
+                                    "description": f"MTA-STS policy mx domain {whois_finding}: {mx_entry}",
+                                    "confidence": "CONFIRMED",
+                                    "severity": "MEDIUM",
+                                    "signature": "N/A",
+                                    "indicator": "Whois Data",
+                                    "trigger": mx_entry,
+                                    "module": type(self),
+                                }
+                            )
+                        )
+
+        return findings
+
+    async def cleanup(self):
+        if self._policy_client:
+            await self._policy_client.aclose()
+            log.debug("MTA-STS policy client closed successfully.")

--- a/tests/mtasts_test.py
+++ b/tests/mtasts_test.py
@@ -1,0 +1,248 @@
+import pytest
+from baddns.modules.mtasts import BadDNS_mtasts
+from baddns.lib.loader import load_signatures
+from .helpers import mock_signature_load
+
+mock_whois_unregistered = {
+    "type": "error",
+    "data": 'No match for "WORSE.DNS".\r\n>>> Last update of whois database: 2023-08-17T14:07:31Z <<<\r\n',
+}
+
+VALID_POLICY = """\
+version: STSv1
+mode: enforce
+mx: mail.bad.dns
+mx: *.bad.dns
+max_age: 86400
+"""
+
+TESTING_POLICY = """\
+version: STSv1
+mode: testing
+mx: mail.bad.dns
+max_age: 86400
+"""
+
+MISMATCHED_POLICY = """\
+version: STSv1
+mode: enforce
+mx: mail.other.dns
+max_age: 86400
+"""
+
+POLICY_WITH_DANGLING_MX = """\
+version: STSv1
+mode: enforce
+mx: mail.worse.dns
+mx: mail.bad.dns
+max_age: 86400
+"""
+
+
+@pytest.mark.asyncio
+async def test_mtasts_no_txt_record(fs, mock_dispatch_whois, configure_mock_resolver):
+    """No _mta-sts TXT record -> dispatch returns False, no findings."""
+    mock_data = {"bad.dns": {}}
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", dns_client=mock_resolver, signatures=[])
+    result = await baddns_mtasts.dispatch()
+    await baddns_mtasts.cleanup()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+async def test_mtasts_dangling_cname_nxdomain(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """TXT exists, mta-sts subdomain has CNAME to NXDOMAIN azure host -> takeover finding."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"CNAME": ["baddns-sts.azurewebsites.net"]},
+        "bad.dns": {"MX": ["mail.bad.dns"]},
+        "_NXDOMAIN": ["baddns-sts.azurewebsites.net"],
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=signatures, dns_client=mock_resolver)
+    findings = None
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert findings
+    expected = {
+        "target": "bad.dns",
+        "description": "Dangling mta-sts subdomain [mta-sts.bad.dns]. Original Event: [Dangling CNAME, probable subdomain takeover (NXDOMAIN technique)]",
+        "confidence": "HIGH",
+        "severity": "HIGH",
+        "signature": "Microsoft Azure Takeover Detection",
+        "indicator": "azurewebsites.net",
+        "trigger": "bad.dns",
+        "module": "MTA-STS",
+    }
+    assert any(expected == finding.to_dict() for finding in findings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+async def test_mtasts_policy_unreachable(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """TXT exists, policy unreachable (HTTP 404) -> orphaned config finding."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+        "bad.dns": {"MX": ["mail.bad.dns"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    httpx_mock.add_response(
+        url="https://mta-sts.bad.dns/.well-known/mta-sts.txt",
+        status_code=404,
+    )
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver)
+    findings = None
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert findings
+    expected = {
+        "target": "bad.dns",
+        "description": "Orphaned MTA-STS TXT record: _mta-sts.bad.dns exists but policy is unreachable (HTTP 404)",
+        "confidence": "MODERATE",
+        "severity": "MEDIUM",
+        "signature": "N/A",
+        "indicator": "MTA-STS Policy Unreachable",
+        "trigger": "_mta-sts.bad.dns",
+        "module": "MTA-STS",
+    }
+    assert any(expected == finding.to_dict() for finding in findings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+async def test_mtasts_mx_mismatch_enforce(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """TXT exists, valid policy in enforce mode, MX mismatch -> mismatch finding."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+        "bad.dns": {"MX": ["mail.bad.dns", "backup.bad.dns"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    httpx_mock.add_response(
+        url="https://mta-sts.bad.dns/.well-known/mta-sts.txt",
+        status_code=200,
+        text=MISMATCHED_POLICY,
+    )
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver)
+    findings = None
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert findings
+    mismatch_findings = [f for f in findings if "MX mismatch" in f.to_dict()["description"]]
+    assert len(mismatch_findings) == 1
+    finding_dict = mismatch_findings[0].to_dict()
+    assert "mail.bad.dns" in finding_dict["description"]
+    assert "backup.bad.dns" in finding_dict["description"]
+    assert finding_dict["confidence"] == "MODERATE"
+    assert finding_dict["severity"] == "MEDIUM"
+    assert finding_dict["module"] == "MTA-STS"
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+async def test_mtasts_mx_mismatch_testing_mode(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """TXT exists, valid policy in testing mode, MX mismatch -> NO finding."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+        "bad.dns": {"MX": ["mail.bad.dns", "backup.bad.dns"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    httpx_mock.add_response(
+        url="https://mta-sts.bad.dns/.well-known/mta-sts.txt",
+        status_code=200,
+        text=TESTING_POLICY,
+    )
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver)
+    findings = None
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert findings is not None
+    mismatch_findings = [f for f in findings if "MX mismatch" in f.to_dict()["description"]]
+    assert len(mismatch_findings) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+@pytest.mark.parametrize("mock_dispatch_whois", [mock_whois_unregistered], indirect=True)
+async def test_mtasts_dangling_mx_domain_unregistered(
+    fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver, cached_suffix_list
+):
+    """TXT exists, valid policy, MX domain unregistered -> WHOIS-based dangling MX finding."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+        "bad.dns": {"MX": ["mail.worse.dns"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    httpx_mock.add_response(
+        url="https://mta-sts.bad.dns/.well-known/mta-sts.txt",
+        status_code=200,
+        text=POLICY_WITH_DANGLING_MX,
+    )
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver)
+    findings = None
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert findings
+    # Filter specifically for MTA-STS policy mx domain findings (not CNAME-wrapped ones)
+    whois_findings = [f for f in findings if "MTA-STS policy mx domain" in f.to_dict()["description"]]
+    assert len(whois_findings) >= 1
+    finding_dict = whois_findings[0].to_dict()
+    assert finding_dict["confidence"] == "CONFIRMED"
+    assert finding_dict["severity"] == "MEDIUM"
+    assert finding_dict["indicator"] == "Whois Data"
+    assert finding_dict["trigger"] == "mail.worse.dns"
+    assert finding_dict["module"] == "MTA-STS"
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+async def test_mtasts_all_correct(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """TXT exists, valid policy, everything correct -> no findings."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+        "bad.dns": {"MX": ["mail.bad.dns"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    httpx_mock.add_response(
+        url="https://mta-sts.bad.dns/.well-known/mta-sts.txt",
+        status_code=200,
+        text=VALID_POLICY,
+    )
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver)
+    findings = None
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert not findings


### PR DESCRIPTION
## Summary
- Adds new `MTA-STS` module that detects subdomain takeovers and misconfigurations related to MTA-STS (RFC 8461)
- Detects 4 finding types: dangling `mta-sts` subdomains (via CNAME delegation), orphaned `_mta-sts` TXT records with unreachable policies, policy MX mismatches in enforce mode, and unregistered/expired domains in policy `mx:` lines
- Includes 7 test cases covering all finding types and negative cases

## Test plan
- [x] `poetry run pytest tests/mtasts_test.py -v` — all 7 new tests pass
- [x] `poetry run pytest --exitfirst --disable-warnings` — full suite (253 tests) passes
- [x] `ruff format --check . && ruff check .` — no lint issues