### PR TITLE
[SignatureBot] Add Fastly subdomain takeover signature

### DIFF
--- a/baddns/signatures/baddns_fastly.yml
+++ b/baddns/signatures/baddns_fastly.yml
@@ -1,0 +1,23 @@
+identifiers:
+  cnames:
+  - type: word
+    value: fastly.net
+  ips: []
+  nameservers: []
+  not_cnames: []
+matcher_rule:
+  matchers:
+  - dsl:
+    - Host != ip
+    type: dsl
+  - condition: or
+    part: body
+    type: word
+    words:
+    - "Fastly error: unknown domain"
+  - status: 500
+    type: status
+  matchers-condition: and
+mode: http
+service_name: Fastly Takeover Detection
+source: self


### PR DESCRIPTION
## Summary

Adds a new signature to detect Fastly subdomain takeover vulnerabilities.

## Research

When a domain has a CNAME pointing to Fastly (`*.fastly.net`, `*.global.fastly.net`, `*.map.fastly.net`, `*.prod.fastly.net`) but the domain is not configured on any Fastly service, Fastly returns a distinctive error:

- **HTTP Status**: `500 Domain Not Found`
- **Server header**: `Varnish`
- **Body**: `Fastly error: unknown domain <hostname>. Please check that this domain has been added to a service.`

Via HTTPS, a slightly different response is returned (421 Misdirected Request with TLS SAN mismatch), but the HTTP fingerprint is the most reliable indicator.

**Claimability**: An attacker can create a free Fastly account, create a new service, and add the target domain as a backend. Multiple bug bounty writeups from 2025 confirm successful takeovers with bounties paid.

This is considered an "edge case" on [can-i-take-over-xyz](https://github.com/EdOverflow/can-i-take-over-xyz) (listed as "Not Vulnerable") because it only works when the parent domain is not already registered with another Fastly customer. However, this is commonly exploitable in practice.

### Fingerprint verification

```
$ curl -sI -H "Host: nonexistent.example.com" http://151.101.1.6
HTTP/1.1 500 Domain Not Found
Server: Varnish

$ curl -s -H "Host: nonexistent.example.com" http://151.101.1.6
<html><head><title>Fastly error: unknown domain nonexistent.example.com</title></head>
<body>Fastly error: unknown domain: nonexistent.example.com. Please check that this domain has been added to a service.</body></html>
```

### References

- https://infosecwriteups.com/fastly-subdomain-takeover-2000-217bb180730f
- https://l1ackerronin.medium.com/my-approach-of-subdomain-takeover-that-pointing-to-fastly-dns-hijacking-6e6bdda84d7c
- https://github.com/EdOverflow/can-i-take-over-xyz