### PR TITLE
[SignatureBot] Add Hashnode subdomain takeover signature

### DIFF
--- a/baddns/signatures/baddns_hashnode.yml
+++ b/baddns/signatures/baddns_hashnode.yml
@@ -1,0 +1,24 @@
+identifiers:
+  cnames:
+  - type: word
+    value: hashnode.network
+  ips: []
+  nameservers: []
+  not_cnames: []
+matcher_rule:
+  matchers:
+  - dsl:
+    - Host != ip
+    type: dsl
+  - condition: and
+    part: body
+    type: word
+    words:
+    - The deployment could not be found on Vercel
+    - DEPLOYMENT_NOT_FOUND
+  - status: 404
+    type: status
+  matchers-condition: and
+mode: http
+service_name: Hashnode Takeover Detection
+source: self


### PR DESCRIPTION
## Summary

Adds a new signature to detect Hashnode subdomain takeover vulnerabilities via dangling CNAME to `hashnode.network`.

## Research

When a Hashnode blog is deleted or a custom domain is removed, the CNAME record pointing to `hashnode.network` may remain. Since `hashnode.network` resolves to Vercel infrastructure (IP `76.76.21.21`), the unclaimed domain returns Vercel's standard deployment-not-found error.

While the existing Vercel signature (`nucleitemplates_vercel-takeover.yml`) would catch this via body text matching, it has no CNAME identifiers. This Hashnode-specific signature adds CNAME-level detection for `hashnode.network`, enabling earlier identification and correct service attribution in findings.

**Claimability**: An attacker can create a new Hashnode blog and add the victim's domain as a custom domain. No domain ownership verification is required for unclaimed domains.

### Fingerprint verification

```
$ dig +short hashnode.network A
76.76.21.21

$ curl -sI -H "Host: nonexistent.hashnode.network" http://76.76.21.21
HTTP/1.1 404 Not Found
Server: Vercel
X-Vercel-Error: DEPLOYMENT_NOT_FOUND

$ curl -s -H "Host: nonexistent.hashnode.network" http://76.76.21.21
The deployment could not be found on Vercel.
DEPLOYMENT_NOT_FOUND
```

### References

- https://github.com/EdOverflow/can-i-take-over-xyz/issues/434
- https://github.com/EdOverflow/can-i-take-over-xyz