### PR TITLE
[SignatureBot] Add Discourse subdomain takeover signature

### DIFF
--- a/baddns/signatures/baddns_discourse.yml
+++ b/baddns/signatures/baddns_discourse.yml
@@ -1,0 +1,11 @@
+identifiers:
+  cnames:
+  - type: word
+    value: trydiscourse.com
+  ips: []
+  nameservers: []
+  not_cnames: []
+matcher_rule: null
+mode: dns_nxdomain
+service_name: Discourse Takeover Detection
+source: self


### PR DESCRIPTION
## Summary

Adds a new signature to detect Discourse subdomain takeover vulnerabilities via dangling CNAME to `trydiscourse.com`.

## Research

Discourse's original hosted forum service used `trydiscourse.com` as the CNAME target for custom domains. The service has since migrated to `discourse.org` (the base domain now 301 redirects there), but subdomains of `trydiscourse.com` return NXDOMAIN, creating a classic dangling CNAME takeover vector.

This is listed as **Vulnerable** on [can-i-take-over-xyz](https://github.com/EdOverflow/can-i-take-over-xyz) with passing CI/CD verification. Detection uses `dns_nxdomain` mode — if a target's CNAME chain includes `trydiscourse.com` and the final resolution is NXDOMAIN, the signature matches.

### Fingerprint verification

```
$ dig +short trydiscourse.com A
172.67.72.58
104.26.9.21
104.26.8.21

$ dig nonexistent-sub.trydiscourse.com A
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 35717
```

The base domain resolves (behind Cloudflare), but arbitrary subdomains return NXDOMAIN, confirming that any CNAME pointing to a non-existent `*.trydiscourse.com` subdomain is dangling.

### References

- https://github.com/EdOverflow/can-i-take-over-xyz (listed as Vulnerable, CI verified)