### PR TITLE
[SignatureBot] Add SendPulse subdomain takeover signature

### DIFF
--- a/baddns/signatures/baddns_sendpulse.yml
+++ b/baddns/signatures/baddns_sendpulse.yml
@@ -1,0 +1,20 @@
+identifiers:
+  cnames:
+  - type: word
+    value: stat-pulse.com
+  - type: word
+    value: sendpulse.com
+  ips: []
+  nameservers: []
+  not_cnames: []
+matcher_rule:
+  matchers:
+  - dsl:
+    - Host != ip
+    type: dsl
+  - status: 502
+    type: status
+  matchers-condition: and
+mode: http
+service_name: SendPulse Takeover Detection
+source: self


### PR DESCRIPTION
## Summary

Adds a new signature to detect SendPulse email tracking subdomain takeover vulnerabilities.

## Research

SendPulse uses `track.stat-pulse.com` (CNAME to `pr.sendpulse.com`) as infrastructure for email tracking domains. When a subdomain has a CNAME pointing to `stat-pulse.com` or `sendpulse.com` without being claimed in the SendPulse platform, an attacker can register and claim it through SendPulse's "Tracking Domains" feature.

This is a somewhat novel takeover vector — rather than serving arbitrary web content, the attacker gains control over email tracking link rewriting. SendPulse rewrites email links as `https://<subdomain>/click/...`, meaning phishing links can appear to originate from the victim's domain.

The unclaimed tracking domain currently returns a `502 Bad Gateway` from nginx, which serves as the HTTP fingerprint combined with the distinctive CNAME patterns.

### Fingerprint verification

```
$ dig +short track.stat-pulse.com
pr.sendpulse.com.
46.4.94.81

$ curl -sI https://track.stat-pulse.com
HTTP/2 502
server: nginx
content-type: text/html
```

### References

- https://github.com/EdOverflow/can-i-take-over-xyz/issues/456