### PR TITLE
Fix false positives when TXT records reference service root domains

### DIFF
--- a/baddns/modules/cname.py
+++ b/baddns/modules/cname.py
@@ -165,6 +165,15 @@ class BadDNS_cname(BadDNS_base):
                             continue
                         log.debug("passed CNAME check")
 
+                        if self.direct_mode and any(
+                            self.subject == cname_dict["value"]
+                            for cname_dict in sig.signature["identifiers"]["cnames"]
+                        ):
+                            log.debug(
+                                f"Direct mode: subject [{self.subject}] is the service domain itself, skipping {sig.signature['service_name']}"
+                            )
+                            continue
+
                     if len(sig.signature["identifiers"]["ips"]) > 0:
                         log.debug(f"Signature contains ips [{sig.signature['identifiers']['ips']}], checking them")
                         if not any(

--- a/tests/txt_test.py
+++ b/tests/txt_test.py
@@ -48,3 +48,27 @@ async def test_txt_dontmatchip(fs, mock_dispatch_whois, configure_mock_resolver)
         findings = baddns_txt.analyze()
 
     assert not findings
+
+
+@pytest.mark.asyncio
+@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
+async def test_txt_direct_mode_service_domain_fp(fs, mock_dispatch_whois, httpx_mock, configure_mock_resolver):
+    """TXT module should not flag service root domains (e.g. mailgun.org from SPF) as vulnerable."""
+    mock_data = {
+        "bad.dns": {"TXT": ["v=spf1 include:mailgun.org ~all"]},
+        "mailgun.org": {"A": ["127.0.0.1"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+
+    httpx_mock.add_response(url="http://mailgun.org/", status_code=404)
+
+    target = "bad.dns"
+    mock_signature_load(fs, "nucleitemplates_mailgun-takeover.yml")
+    signatures = load_signatures("/tmp/signatures")
+    baddns_txt = BadDNS_txt(target, signatures=signatures, dns_client=mock_resolver)
+
+    findings = None
+    if await baddns_txt.dispatch():
+        findings = baddns_txt.analyze()
+
+    assert not findings


### PR DESCRIPTION
## Summary

- When the TXT module extracts a domain from a TXT record (e.g. `mailgun.org` from an SPF `include:`), it runs that domain through the CNAME module in direct mode. If the domain exactly matches a signature's cname identifier (e.g. `mailgun.org` in the Mailgun signature) and the HTTP response happens to match (404), a false positive is generated — the service provider's own domain is not a takeover target.
- Adds a direct-mode guard in the CNAME module's HTTP signature matching: if the subject exactly equals a signature's cname identifier, skip it. This applies to all 98 HTTP-mode signatures.
- Adds a regression test covering the Mailgun/SPF case.