### PR TITLE
Restore 100% test coverage

### DIFF
--- a/tests/cli_extended_test.py
+++ b/tests/cli_extended_test.py
@@ -5,6 +5,14 @@ from baddns import cli
 from baddns.lib.errors import BadDNSCLIException, BadDNSSignatureException
 
 
+class TestVersionModule:
+    def test_version_importable(self):
+        from baddns.__version__ import __version__
+
+        assert isinstance(__version__, str)
+        assert len(__version__) > 0
+
+
 class TestPrintVersion:
     def test_print_version_found(self, capsys, monkeypatch):
         monkeypatch.setattr("importlib.metadata.version", lambda name: "1.2.3")

--- a/tests/dnsmanager_test.py
+++ b/tests/dnsmanager_test.py
@@ -260,6 +260,42 @@ class TestProcessAnswer:
         processed = self.mgr.process_answer(FakeResult(), "NSEC")
         assert "next.example.com" in processed
 
+    def test_unknown_record_dict_with_rdata(self):
+        """UNKNOWN record with dict rdata containing raw bytes."""
+
+        class FakeRecord:
+            def __init__(self):
+                self.rdata = {"UNKNOWN": {"rdata": {"anything": list(b"host.example.com")}}}
+
+        class FakeResponse:
+            def __init__(self):
+                self.answers = [FakeRecord()]
+
+        class FakeResult:
+            def __init__(self):
+                self.response = FakeResponse()
+
+        processed = self.mgr.process_answer(FakeResult(), "UNKNOWN")
+        assert "host.example.com" in processed
+
+    def test_unknown_record_dict_empty_rdata(self):
+        """UNKNOWN record with dict rdata but empty anything field."""
+
+        class FakeRecord:
+            def __init__(self):
+                self.rdata = {"UNKNOWN": {"rdata": {"anything": []}}}
+
+        class FakeResponse:
+            def __init__(self):
+                self.answers = [FakeRecord()]
+
+        class FakeResult:
+            def __init__(self):
+                self.response = FakeResponse()
+
+        processed = self.mgr.process_answer(FakeResult(), "UNKNOWN")
+        assert processed == []
+
 
 class TestDoResolve:
     def setup_method(self):

--- a/tests/dnswalk_extended_test.py
+++ b/tests/dnswalk_extended_test.py
@@ -35,6 +35,51 @@ class TestAResolve:
         result = await dw.a_resolve("ns.example.com")
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_a_resolve_with_glue(self):
+        mock_dns_manager = MagicMock()
+        mock_dns_manager.do_resolve = AsyncMock(return_value=["9.9.9.9"])
+        dw = DnsWalk(mock_dns_manager)
+        glue = {"ns.example.com": ["1.2.3.4", "5.6.7.8"]}
+        result = await dw.a_resolve("ns.example.com", glue=glue)
+        assert result == ["1.2.3.4", "5.6.7.8"]
+        # Should use glue, not call do_resolve
+        mock_dns_manager.do_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_resolve_with_glue_miss(self):
+        mock_dns_manager = MagicMock()
+        mock_dns_manager.do_resolve = AsyncMock(return_value=["9.9.9.9"])
+        dw = DnsWalk(mock_dns_manager)
+        glue = {"other.example.com": ["1.2.3.4"]}
+        result = await dw.a_resolve("ns.example.com", glue=glue)
+        # Glue doesn't have this host, falls through to do_resolve
+        assert result == ["9.9.9.9"]
+
+
+class TestExtractGlueRecords:
+    def test_with_a_records(self):
+        response = dns.message.Message()
+        rrset = dns.rrset.from_text("ns1.example.com.", 3600, dns.rdataclass.IN, dns.rdatatype.A, "1.2.3.4")
+        response.additional.append(rrset)
+        rrset2 = dns.rrset.from_text("ns2.example.com.", 3600, dns.rdataclass.IN, dns.rdatatype.A, "5.6.7.8")
+        response.additional.append(rrset2)
+        glue = DnsWalk.extract_glue_records(response)
+        assert glue["ns1.example.com"] == ["1.2.3.4"]
+        assert glue["ns2.example.com"] == ["5.6.7.8"]
+
+    def test_empty_additional(self):
+        response = dns.message.Message()
+        glue = DnsWalk.extract_glue_records(response)
+        assert glue == {}
+
+    def test_non_a_records_ignored(self):
+        response = dns.message.Message()
+        rrset = dns.rrset.from_text("ns1.example.com.", 3600, dns.rdataclass.IN, dns.rdatatype.AAAA, "2001:db8::1")
+        response.additional.append(rrset)
+        glue = DnsWalk.extract_glue_records(response)
+        assert glue == {}
+
 
 class TestRawQueryWithRetry:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add tests for UNKNOWN record type handling in `DNSManager.process_answer`
- Add tests for `DnsWalk.extract_glue_records` with A/AAAA/empty additional sections
- Add tests for `DnsWalk.a_resolve` glue record hit and miss paths
- Add test for `__version__` module import
- 363 tests, 100% coverage (was 99% / 18 lines missing)