### PR TITLE
[SignatureBot] Add or update signature nucleitemplates_aws-bucket-takeover.yml

### DIFF
--- a/baddns/signatures/nucleitemplates_aws-bucket-takeover.yml
+++ b/baddns/signatures/nucleitemplates_aws-bucket-takeover.yml
@@ -6,8 +6,6 @@ identifiers:
   - type: word
     value: amazonaws.com
   - type: word
-    value: wasabisys.com
-  - type: word
     value: ks3.ksyun.com
   - type: word
     value: kss.ksyun.com
@@ -82,9 +80,16 @@ matcher_rule:
     - BucketName
   - dsl:
     - contains(tolower(header), 'x-guploader-uploadid')
+    - contains(tolower(header), "aliyunoss")
     negative: true
     type: dsl
+  - negative: true
+    part: host
+    regex:
+    - ^[a-z0-9][a-z0-9-]+-[0-9]{12}-[a-z0-9-]+-an\.s3\.[a-z0-9-]+\.amazonaws\.com
+    type: regex
   matchers-condition: and
 mode: http
+negative_signature: false
 service_name: AWS Bucket Takeover Detection
 source: nucleitemplates


### PR DESCRIPTION
## Add or update signature: nucleitemplates_aws-bucket-takeover.yml
This PR adds or updates the follow signature:
```
identifiers:
  cnames: []
  ips: []
  nameservers: []
  not_cnames:
  - type: word
    value: amazonaws.com
  - type: word
    value: ks3.ksyun.com
  - type: word
    value: kss.ksyun.com
  - type: word
    value: kss3.ksyun.com
  - type: word
    value: ks3-cn-beijing.ksyun.com
  - type: word
    value: ks3-cn-guangzhou.ksyun.com
  - type: word
    value: ks3-cn-hk-1.ksyun.com
  - type: word
    value: ks3-cn-shanghai.ksyun.com
  - type: word
    value: ks3-jr-beijing.ksyun.com
  - type: word
    value: ks3-jr-shanghai.ksyun.com
  - type: word
    value: ks3-rus.ksyun.com
  - type: word
    value: ks3-sgp.ksyun.com
  - type: word
    value: obs.jrzq.huaweicloud.com
  - type: word
    value: obs.petalpay.huaweicloud.com
  - type: word
    value: oss-cn-hangzhou.aliyuncs.com
  - type: word
    value: oss-cn-shanghai.aliyuncs.com
  - type: word
    value: oss-cn-qingdao.aliyuncs.com
  - type: word
    value: oss-cn-beijing.aliyuncs.com
  - type: word
    value: oss-cn-zhangjiakou.aliyuncs.com
  - type: word
    value: oss-cn-huhehaote.aliyuncs.com
  - type: word
    value: oss-cn-shenzhen.aliyuncs.com
  - type: word
    value: oss-cn-hongkong.aliyuncs.com
  - type: word
    value: oss-us-west-1.aliyuncs.com
  - type: word
    value: oss-us-east-1.aliyuncs.com
  - type: word
    value: oss-ap-southeast-1.aliyuncs.com
  - type: word
    value: oss-ap-southeast-2.aliyuncs.com
  - type: word
    value: oss-ap-southeast-3.aliyuncs.com
  - type: word
    value: oss-ap-southeast-5.aliyuncs.com
  - type: word
    value: oss-ap-south-1.aliyuncs.com
  - type: word
    value: oss-ap-northeast-1.aliyuncs.com
  - type: word
    value: oss-eu-central-1.aliyuncs.com
  - type: word
    value: oss-me-east-1.aliyuncs.com
matcher_rule:
  matchers:
  - dsl:
    - Host != ip
    type: dsl
  - condition: and
    part: body
    type: word
    words:
    - The specified bucket does not exist
    - BucketName
  - dsl:
    - contains(tolower(header), 'x-guploader-uploadid')
    - contains(tolower(header), "aliyunoss")
    negative: true
    type: dsl
  - negative: true
    part: host
    regex:
    - ^[a-z0-9][a-z0-9-]+-[0-9]{12}-[a-z0-9-]+-an\.s3\.[a-z0-9-]+\.amazonaws\.com
    type: regex
  matchers-condition: and
mode: http
negative_signature: false
service_name: AWS Bucket Takeover Detection
source: nucleitemplates
```
