### PR TITLE
Gate DMARC/SPF/MTA-STS on MX presence to reduce noise

### DIFF
--- a/baddns/base.py
+++ b/baddns/base.py
@@ -53,4 +53,15 @@ class BadDNS_base:
 
 
 def get_all_modules(*args, **kwargs):
-    return [m for m in BadDNS_base.__subclasses__()]
+    seen = []
+
+    def _walk(cls):
+        for sub in cls.__subclasses__():
+            # Only concrete modules have a `name` class attribute; intermediate
+            # bases like BadDNS_email_base do not.
+            if getattr(sub, "name", None) and sub not in seen:
+                seen.append(sub)
+            _walk(sub)
+
+    _walk(BadDNS_base)
+    return seen

--- a/baddns/cli.py
+++ b/baddns/cli.py
@@ -109,6 +109,7 @@ async def execute_module(
     direct_mode=False,
     min_confidence=None,
     min_severity=None,
+    disable_mx_gate=False,
 ):
     findings = None
     try:
@@ -119,6 +120,7 @@ async def execute_module(
             dns_client=dns_client,
             cli=True,
             direct_mode=direct_mode,
+            disable_mx_gate=disable_mx_gate,
         )
     except BadDNSSignatureException as e:
         log.error(f"Error loading signatures: {e}")
@@ -185,6 +187,12 @@ async def _main():
         "--min-severity",
         type=validate_severity,
         help="Minimum severity level to report. Levels: CRITICAL, HIGH, MEDIUM, LOW (exclude INFO)",
+    )
+
+    parser.add_argument(
+        "--disable-mx-gate",
+        action="store_true",
+        help="Run email-related modules (DMARC, SPF, MTA-STS misconfigurations) even when the domain has no MX records at the target or its registered domain.",
     )
 
     parser.add_argument("target", nargs="?", type=validate_target, help="subdomain to analyze")
@@ -260,6 +268,7 @@ async def _main():
             direct_mode=direct_mode,
             min_confidence=args.min_confidence,
             min_severity=args.min_severity,
+            disable_mx_gate=args.disable_mx_gate,
         )
 
 

--- a/baddns/lib/email_base.py
+++ b/baddns/lib/email_base.py
@@ -1,0 +1,63 @@
+import logging
+
+import tldextract
+
+from baddns.base import BadDNS_base
+from baddns.lib.dnsmanager import DNSManager
+
+log = logging.getLogger(__name__)
+
+
+class BadDNS_email_base(BadDNS_base):
+    """Shared base for email-related modules (DMARC, SPF, MTA-STS).
+
+    Provides an MX-presence check so callers can skip checks that only matter
+    for domains that actually receive mail. The target's own MX takes precedence;
+    if absent, the registered (apex) domain is consulted, since email infra is
+    typically organizational rather than per-leaf-subdomain.
+    """
+
+    def __init__(self, target, **kwargs):
+        super().__init__(target, **kwargs)
+        self.disable_mx_gate = kwargs.get("disable_mx_gate", False)
+        self._mx_present_cache = None
+
+    async def has_email_infra(self):
+        """True if the target or its registered domain has any MX records."""
+        if self._mx_present_cache is not None:
+            return self._mx_present_cache
+
+        mx_omit = ["A", "AAAA", "CNAME", "NS", "SOA", "TXT", "NSEC"]
+
+        sub_dns = DNSManager(self.target, dns_client=self.dns_client, custom_nameservers=self.custom_nameservers)
+        await sub_dns.dispatchDNS(omit_types=mx_omit)
+        if sub_dns.answers.get("MX"):
+            self._mx_present_cache = True
+            return True
+
+        registered_domain = tldextract.extract(self.target).registered_domain
+        if registered_domain and registered_domain != self.target:
+            apex_dns = DNSManager(
+                registered_domain, dns_client=self.dns_client, custom_nameservers=self.custom_nameservers
+            )
+            await apex_dns.dispatchDNS(omit_types=mx_omit)
+            if apex_dns.answers.get("MX"):
+                self._mx_present_cache = True
+                return True
+
+        self._mx_present_cache = False
+        return False
+
+    async def mx_gate_skips(self):
+        """True if the module should skip its email-config checks due to no MX.
+
+        Returns False when the gate is disabled via disable_mx_gate.
+        """
+        if self.disable_mx_gate:
+            return False
+        if await self.has_email_infra():
+            return False
+        log.debug(
+            f"Skipping email checks for [{self.target}] in [{self.__class__.__name__}] - no MX at target or apex"
+        )
+        return True

--- a/baddns/modules/dmarc.py
+++ b/baddns/modules/dmarc.py
@@ -1,4 +1,4 @@
-from baddns.base import BadDNS_base
+from baddns.lib.email_base import BadDNS_email_base
 from baddns.lib.dnsmanager import DNSManager
 from baddns.lib.findings import Finding
 
@@ -8,7 +8,7 @@ import tldextract
 log = logging.getLogger(__name__)
 
 
-class BadDNS_dmarc(BadDNS_base):
+class BadDNS_dmarc(BadDNS_email_base):
     name = "DMARC"
     description = "Check for missing or misconfigured DMARC records"
     skip_cloud_targets = True
@@ -40,6 +40,8 @@ class BadDNS_dmarc(BadDNS_base):
         return tags
 
     async def _dispatch(self):
+        if await self.mx_gate_skips():
+            return False
         # Step 1: Check _dmarc.<target> (RFC 7489 Section 6.6.3)
         await self.target_dnsmanager.dispatchDNS(omit_types=["A", "AAAA", "CNAME", "NS", "SOA", "MX", "NSEC"])
         txt_records = self.target_dnsmanager.answers["TXT"]

--- a/baddns/modules/mtasts.py
+++ b/baddns/modules/mtasts.py
@@ -3,7 +3,7 @@ import fnmatch
 
 from blasthttp import BlastHTTP
 
-from baddns.base import BadDNS_base
+from baddns.lib.email_base import BadDNS_email_base
 from baddns.lib.dnsmanager import DNSManager
 from baddns.lib.httpmanager import USER_AGENT
 from baddns.lib.whoismanager import WhoisManager
@@ -13,7 +13,7 @@ from baddns.modules.cname import BadDNS_cname
 log = logging.getLogger(__name__)
 
 
-class BadDNS_mtasts(BadDNS_base):
+class BadDNS_mtasts(BadDNS_email_base):
     name = "MTA-STS"
     description = "Check for MTA-STS misconfigurations and dangling mta-sts subdomains"
 
@@ -33,6 +33,7 @@ class BadDNS_mtasts(BadDNS_base):
         self.policy_error = None
         self.mx_whois_results = {}
         self.mta_sts_host = f"mta-sts.{target}"
+        self._has_mx = None
 
     async def _dispatch(self):
         # Step 1: Check for _mta-sts TXT record
@@ -135,6 +136,9 @@ class BadDNS_mtasts(BadDNS_base):
                 await whois_mgr.dispatchWHOIS()
                 self.mx_whois_results[mx_entry] = whois_mgr
 
+        # Cache MX presence for analyze() to gate misconfig-only findings
+        self._has_mx = await self.has_email_infra()
+
         return True
 
     @staticmethod
@@ -186,14 +190,19 @@ class BadDNS_mtasts(BadDNS_base):
     def analyze(self):
         findings = []
 
-        # Finding 1: Dangling mta-sts subdomain via CNAME delegation
+        # Finding 1: Dangling mta-sts subdomain via CNAME delegation — runs
+        # regardless of MX presence; this is a takeover vector independent of mail flow.
         if self.cname_findings_direct:
             findings.extend(self._convert_cname_findings(self.cname_findings_direct))
         if self.cname_findings:
             findings.extend(self._convert_cname_findings(self.cname_findings))
 
+        # Misconfig findings (orphaned TXT, policy/MX mismatch) only matter if mail
+        # actually flows. Skip them when the domain has no MX (gate honors disable_mx_gate).
+        emit_misconfig = self.disable_mx_gate or self._has_mx
+
         # Finding 2: Orphaned TXT record with unreachable policy
-        if self.policy_error and not self.cname_findings_direct and not self.cname_findings:
+        if emit_misconfig and self.policy_error and not self.cname_findings_direct and not self.cname_findings:
             findings.append(
                 Finding(
                     {
@@ -212,8 +221,8 @@ class BadDNS_mtasts(BadDNS_base):
         if self.policy:
             actual_mx = self.mx_dnsmanager.answers.get("MX") or []
 
-            # Finding 3: Policy MX mismatch (only in enforce mode)
-            if self.policy.get("mode") == "enforce" and actual_mx:
+            # Finding 3: Policy MX mismatch (only in enforce mode) — gated on MX presence
+            if emit_misconfig and self.policy.get("mode") == "enforce" and actual_mx:
                 unmatched = []
                 for mx_host in actual_mx:
                     if not any(self._mx_matches(pattern, mx_host) for pattern in self.policy["mx"]):

--- a/baddns/modules/spf.py
+++ b/baddns/modules/spf.py
@@ -1,4 +1,4 @@
-from baddns.base import BadDNS_base
+from baddns.lib.email_base import BadDNS_email_base
 from baddns.lib.dnsmanager import DNSManager
 from baddns.lib.whoismanager import WhoisManager
 from baddns.lib.findings import Finding
@@ -9,7 +9,7 @@ import tldextract
 log = logging.getLogger(__name__)
 
 
-class BadDNS_spf(BadDNS_base):
+class BadDNS_spf(BadDNS_email_base):
     name = "SPF"
     description = "Check for missing or misconfigured SPF records and hijackable include/redirect domains"
     skip_cloud_targets = True
@@ -93,6 +93,8 @@ class BadDNS_spf(BadDNS_base):
         return result
 
     async def _dispatch(self):
+        if await self.mx_gate_skips():
+            return False
         await self.target_dnsmanager.dispatchDNS(omit_types=["A", "AAAA", "CNAME", "NS", "SOA", "MX", "NSEC"])
         txt_records = self.target_dnsmanager.answers["TXT"]
 

--- a/tests/dmarc_test.py
+++ b/tests/dmarc_test.py
@@ -23,7 +23,7 @@ async def test_dmarc_no_txt_records(configure_mock_resolver):
     mock_data = {}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 1
@@ -40,7 +40,7 @@ async def test_dmarc_txt_exists_but_no_dmarc(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=spf1 include:example.com ~all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 1
@@ -52,7 +52,7 @@ async def test_dmarc_p_none(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -65,7 +65,7 @@ async def test_dmarc_sp_none(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; sp=none; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -78,7 +78,7 @@ async def test_dmarc_pct_less_than_100(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; pct=50; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -90,7 +90,7 @@ async def test_dmarc_no_rua(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -102,7 +102,7 @@ async def test_dmarc_fully_compliant(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -113,7 +113,7 @@ async def test_dmarc_multiple_findings_p_none_no_rua(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -127,7 +127,7 @@ async def test_dmarc_all_four_issues(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none; sp=none; pct=25"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -143,7 +143,7 @@ async def test_dmarc_pct_100_no_finding(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; pct=100; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -154,7 +154,7 @@ async def test_dmarc_p_quarantine_no_p_none_finding(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=quarantine; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -166,7 +166,7 @@ async def test_dmarc_absent_sp_no_finding(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -178,7 +178,7 @@ async def test_dmarc_case_insensitivity(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["V=DMARC1; P=None; RUA=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -190,7 +190,7 @@ async def test_dmarc_invalid_pct_no_crash(configure_mock_resolver):
     mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=reject; pct=abc; rua=mailto:dmarc@bad.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -206,7 +206,7 @@ async def test_dmarc_subdomain_inherits_reject(configure_mock_resolver):
     mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -218,7 +218,7 @@ async def test_dmarc_subdomain_inherits_sp_none(configure_mock_resolver):
     mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; sp=none; rua=mailto:dmarc@example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 1
@@ -232,7 +232,7 @@ async def test_dmarc_subdomain_inherits_p_none(configure_mock_resolver):
     mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=none; rua=mailto:dmarc@example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -245,7 +245,7 @@ async def test_dmarc_subdomain_no_org_record(configure_mock_resolver):
     mock_data = {}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 1
@@ -261,7 +261,7 @@ async def test_dmarc_subdomain_own_record_overrides(configure_mock_resolver):
     }
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -275,7 +275,7 @@ async def test_dmarc_subdomain_inherits_sp_quarantine(configure_mock_resolver):
     mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; sp=quarantine; rua=mailto:dmarc@example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -287,7 +287,7 @@ async def test_dmarc_subdomain_inherits_low_pct(configure_mock_resolver):
     mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; pct=25; rua=mailto:dmarc@example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -301,7 +301,7 @@ async def test_dmarc_deep_subdomain_inherits(configure_mock_resolver):
     mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "a.b.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -313,7 +313,7 @@ async def test_dmarc_subdomain_inherited_invalid_pct(configure_mock_resolver):
     mock_data = {"_dmarc.example.com": {"TXT": ["v=DMARC1; p=reject; pct=abc; rua=mailto:dmarc@example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -329,9 +329,57 @@ async def test_dmarc_cloud_target_skipped(configure_mock_resolver):
     mock_data = {}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_dmarc(target, dns_client=mock_resolver)
+    m = BadDNS_dmarc(target, dns_client=mock_resolver, disable_mx_gate=True)
     mock_cc = MagicMock()
     mock_cc.lookup = AsyncMock(return_value=[{"name": "SomeCloud", "tags": ["cloud"]}])
     with patch("baddns.base.CloudCheck", return_value=mock_cc):
         result = await m.dispatch()
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_dmarc_mx_gate_skips_when_no_mx(configure_mock_resolver):
+    """With the MX gate on (default), DMARC skips when neither target nor apex has MX."""
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_dmarc("bad.com", dns_client=mock_resolver)
+    assert await m.dispatch() is False
+
+
+@pytest.mark.asyncio
+async def test_dmarc_mx_gate_runs_with_target_mx(configure_mock_resolver):
+    """Subdomain MX takes precedence — gate passes even if apex has none."""
+    mock_data = {
+        "sub.bad.com": {"MX": ["mail.bad.com."]},
+        "_dmarc.sub.bad.com": {"TXT": ["v=DMARC1; p=none"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_dmarc("sub.bad.com", dns_client=mock_resolver)
+    assert await m.dispatch() is True
+    findings = m.analyze()
+    assert any(f.to_dict()["indicator"] == "p=none" for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_dmarc_mx_gate_runs_with_apex_mx(configure_mock_resolver):
+    """Subdomain with no MX falls back to apex MX; gate passes."""
+    mock_data = {
+        "bad.com": {"MX": ["mail.bad.com."]},
+        "_dmarc.sub.bad.com": {"TXT": ["v=DMARC1; p=none"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_dmarc("sub.bad.com", dns_client=mock_resolver)
+    assert await m.dispatch() is True
+    findings = m.analyze()
+    assert any(f.to_dict()["indicator"] == "p=none" for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_dmarc_mx_gate_disabled_runs_without_mx(configure_mock_resolver):
+    """disable_mx_gate=True opt-out keeps DMARC running even without MX."""
+    mock_data = {"_dmarc.bad.com": {"TXT": ["v=DMARC1; p=none"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_dmarc("bad.com", dns_client=mock_resolver, disable_mx_gate=True)
+    assert await m.dispatch() is True
+    findings = m.analyze()
+    assert any(f.to_dict()["indicator"] == "p=none" for f in findings)

--- a/tests/mtasts_test.py
+++ b/tests/mtasts_test.py
@@ -45,7 +45,7 @@ async def test_mtasts_no_txt_record(fs, mock_dispatch_whois, configure_mock_reso
     mock_data = {"bad.dns": {}}
     mock_resolver = configure_mock_resolver(mock_data)
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", dns_client=mock_resolver, signatures=[])
+    baddns_mtasts = BadDNS_mtasts("bad.dns", dns_client=mock_resolver, signatures=[], disable_mx_gate=True)
     result = await baddns_mtasts.dispatch()
     await baddns_mtasts.cleanup()
 
@@ -58,7 +58,7 @@ async def test_mtasts_txt_exists_no_sts(fs, mock_dispatch_whois, configure_mock_
     mock_data = {"_mta-sts.bad.dns": {"TXT": ["v=spf1 include:example.com ~all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", dns_client=mock_resolver, signatures=[])
+    baddns_mtasts = BadDNS_mtasts("bad.dns", dns_client=mock_resolver, signatures=[], disable_mx_gate=True)
     result = await baddns_mtasts.dispatch()
     await baddns_mtasts.cleanup()
 
@@ -88,7 +88,9 @@ async def test_mtasts_dangling_cname_nxdomain(fs, mock_dispatch_whois, mock_http
     mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
     signatures = load_signatures("/tmp/signatures")
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=signatures, dns_client=mock_resolver, http_client=mock_http)
+    baddns_mtasts = BadDNS_mtasts(
+        "bad.dns", signatures=signatures, dns_client=mock_resolver, http_client=mock_http, disable_mx_gate=True
+    )
     findings = None
     if await baddns_mtasts.dispatch():
         findings = baddns_mtasts.analyze()
@@ -123,7 +125,9 @@ async def test_mtasts_policy_unreachable(fs, mock_dispatch_whois, mock_http, con
         status=404,
     )
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    baddns_mtasts = BadDNS_mtasts(
+        "bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http, disable_mx_gate=True
+    )
     findings = None
     if await baddns_mtasts.dispatch():
         findings = baddns_mtasts.analyze()
@@ -159,7 +163,9 @@ async def test_mtasts_mx_mismatch_enforce(fs, mock_dispatch_whois, mock_http, co
         body=MISMATCHED_POLICY,
     )
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    baddns_mtasts = BadDNS_mtasts(
+        "bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http, disable_mx_gate=True
+    )
     findings = None
     if await baddns_mtasts.dispatch():
         findings = baddns_mtasts.analyze()
@@ -192,7 +198,9 @@ async def test_mtasts_mx_mismatch_testing_mode(fs, mock_dispatch_whois, mock_htt
         body=TESTING_POLICY,
     )
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    baddns_mtasts = BadDNS_mtasts(
+        "bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http, disable_mx_gate=True
+    )
     findings = None
     if await baddns_mtasts.dispatch():
         findings = baddns_mtasts.analyze()
@@ -222,7 +230,9 @@ async def test_mtasts_dangling_mx_domain_unregistered(
         body=POLICY_WITH_DANGLING_MX,
     )
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    baddns_mtasts = BadDNS_mtasts(
+        "bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http, disable_mx_gate=True
+    )
     findings = None
     if await baddns_mtasts.dispatch():
         findings = baddns_mtasts.analyze()
@@ -241,6 +251,89 @@ async def test_mtasts_dangling_mx_domain_unregistered(
 
 
 @pytest.mark.asyncio
+async def test_mtasts_mx_gate_skips_orphaned_txt(fs, mock_dispatch_whois, mock_http, configure_mock_resolver):
+    """With MX gate on and no MX, orphaned-TXT finding should be suppressed."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    mock_http.add_response(url="https://mta-sts.bad.dns/.well-known/mta-sts.txt", status=404)
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    findings = []
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert not any("Orphaned MTA-STS TXT" in f.to_dict()["description"] for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_mtasts_mx_gate_skips_mismatch(fs, mock_dispatch_whois, mock_http, configure_mock_resolver):
+    """With MX gate on and no MX, MX-mismatch finding should be suppressed."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    mock_http.add_response(url="https://mta-sts.bad.dns/.well-known/mta-sts.txt", status=200, body=MISMATCHED_POLICY)
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    findings = []
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert not any("MX mismatch" in f.to_dict()["description"] for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_mtasts_mx_gate_keeps_dangling_subdomain(fs, mock_dispatch_whois, mock_http, configure_mock_resolver):
+    """Dangling mta-sts.* subdomain takeover finding must run even without MX."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"CNAME": ["baddns-sts.azurewebsites.net"]},
+        "_NXDOMAIN": ["baddns-sts.azurewebsites.net"],
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    mock_signature_load(fs, "nucleitemplates_azure-takeover-detection.yml")
+    signatures = load_signatures("/tmp/signatures")
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=signatures, dns_client=mock_resolver, http_client=mock_http)
+    findings = []
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert any("Dangling mta-sts subdomain" in f.to_dict()["description"] for f in findings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mock_dispatch_whois", [mock_whois_unregistered], indirect=True)
+async def test_mtasts_mx_gate_keeps_policy_mx_whois(
+    fs, mock_dispatch_whois, mock_http, configure_mock_resolver, cached_suffix_list
+):
+    """WHOIS-based policy MX takeover finding must run even without MX (still a takeover)."""
+    mock_data = {
+        "_mta-sts.bad.dns": {"TXT": ["v=STSv1; id=abc123"]},
+        "mta-sts.bad.dns": {"A": ["1.2.3.4"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    mock_http.add_response(
+        url="https://mta-sts.bad.dns/.well-known/mta-sts.txt", status=200, body=POLICY_WITH_DANGLING_MX
+    )
+
+    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    findings = []
+    if await baddns_mtasts.dispatch():
+        findings = baddns_mtasts.analyze()
+    await baddns_mtasts.cleanup()
+
+    assert any("MTA-STS policy mx domain" in f.to_dict()["description"] for f in findings)
+
+
+@pytest.mark.asyncio
 async def test_mtasts_all_correct(fs, mock_dispatch_whois, mock_http, configure_mock_resolver):
     """TXT exists, valid policy, everything correct -> no findings."""
     mock_data = {
@@ -256,7 +349,9 @@ async def test_mtasts_all_correct(fs, mock_dispatch_whois, mock_http, configure_
         body=VALID_POLICY,
     )
 
-    baddns_mtasts = BadDNS_mtasts("bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http)
+    baddns_mtasts = BadDNS_mtasts(
+        "bad.dns", signatures=[], dns_client=mock_resolver, http_client=mock_http, disable_mx_gate=True
+    )
     findings = None
     if await baddns_mtasts.dispatch():
         findings = baddns_mtasts.analyze()

--- a/tests/spf_test.py
+++ b/tests/spf_test.py
@@ -65,7 +65,7 @@ async def test_spf_no_txt_records(configure_mock_resolver):
     mock_data = {}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 1
@@ -82,7 +82,7 @@ async def test_spf_txt_exists_but_no_spf(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=DMARC1; p=reject"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 1
@@ -94,7 +94,7 @@ async def test_spf_plus_all(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 +all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -107,7 +107,7 @@ async def test_spf_bare_all_implicit_plus(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -119,7 +119,7 @@ async def test_spf_neutral_all(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 ?all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -133,7 +133,7 @@ async def test_spf_softfail_all_no_finding(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 ~all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -147,7 +147,7 @@ async def test_spf_hardfail_all_no_finding(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -158,7 +158,7 @@ async def test_spf_multiple_records(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 -all", "v=spf1 include:example.com -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -172,7 +172,7 @@ async def test_spf_dns_lookup_exceeds_10(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": [f"v=spf1 {includes} -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -186,7 +186,7 @@ async def test_spf_dns_lookup_at_10_no_finding(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": [f"v=spf1 {includes} -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -206,7 +206,7 @@ async def test_spf_mixed_mechanisms_counting(configure_mock_resolver):
     }
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     # 2 includes + a + mx + ptr + exists + redirect = 7
     assert m.parsed_spf["dns_lookup_count"] == 7
@@ -218,7 +218,7 @@ async def test_spf_fully_compliant(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 include:_spf.google.com ~all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -230,7 +230,7 @@ async def test_spf_case_insensitive(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["V=SPF1 -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -242,7 +242,7 @@ async def test_spf_no_all_mechanism_no_finding(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 include:example.com"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -256,7 +256,7 @@ async def test_spf_qualified_mechanisms_parsed(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 ~include:example.com -mx -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     assert m.parsed_spf["includes"] == ["example.com"]
     assert m.parsed_spf["dns_lookup_count"] == 2  # include + mx
@@ -268,7 +268,7 @@ async def test_spf_empty_include_no_crash(configure_mock_resolver):
     mock_data = {"bad.com": {"TXT": ["v=spf1 include: -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert not any(f.to_dict()["indicator"] == "Whois Data" for f in findings)
@@ -285,7 +285,7 @@ async def test_spf_include_unregistered(fs, mock_dispatch_whois, configure_mock_
         mock_resolver = configure_mock_resolver(mock_data)
 
         target = "bad.dns"
-        m = BadDNS_spf(target, dns_client=mock_resolver)
+        m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
         findings = None
         if await m.dispatch():
             findings = m.analyze()
@@ -312,7 +312,7 @@ async def test_spf_include_expired(fs, mock_dispatch_whois, configure_mock_resol
         mock_resolver = configure_mock_resolver(mock_data)
 
         target = "bad.dns"
-        m = BadDNS_spf(target, dns_client=mock_resolver)
+        m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
         findings = None
         if await m.dispatch():
             findings = m.analyze()
@@ -339,7 +339,7 @@ async def test_spf_redirect_unregistered(fs, mock_dispatch_whois, configure_mock
         mock_resolver = configure_mock_resolver(mock_data)
 
         target = "bad.dns"
-        m = BadDNS_spf(target, dns_client=mock_resolver)
+        m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
         findings = None
         if await m.dispatch():
             findings = m.analyze()
@@ -366,7 +366,7 @@ async def test_spf_include_registered_no_finding(fs, mock_dispatch_whois, config
         mock_resolver = configure_mock_resolver(mock_data)
 
         target = "bad.dns"
-        m = BadDNS_spf(target, dns_client=mock_resolver)
+        m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
         findings = None
         if await m.dispatch():
             findings = m.analyze()
@@ -383,7 +383,7 @@ async def test_spf_combined_policy_and_takeover(fs, mock_dispatch_whois, configu
         mock_resolver = configure_mock_resolver(mock_data)
 
         target = "bad.dns"
-        m = BadDNS_spf(target, dns_client=mock_resolver)
+        m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
         findings = None
         if await m.dispatch():
             findings = m.analyze()
@@ -403,7 +403,7 @@ async def test_spf_subdomain_inherits_from_org(configure_mock_resolver):
     mock_data = {"example.com": {"TXT": ["v=spf1 include:_spf.google.com -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "www.example.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -417,7 +417,7 @@ async def test_spf_subdomain_inherits_policy_issues(configure_mock_resolver):
     mock_data = {"example.com": {"TXT": ["v=spf1 +all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "www.example.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -431,7 +431,7 @@ async def test_spf_subdomain_no_org_record(configure_mock_resolver):
     mock_data = {}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "www.example.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 1
@@ -447,7 +447,7 @@ async def test_spf_subdomain_own_record_overrides(configure_mock_resolver):
     }
     mock_resolver = configure_mock_resolver(mock_data)
     target = "sub.example.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     indicators = [f.to_dict()["indicator"] for f in findings]
@@ -460,7 +460,7 @@ async def test_spf_deep_subdomain_inherits(configure_mock_resolver):
     mock_data = {"example.com": {"TXT": ["v=spf1 include:_spf.google.com -all"]}}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "a.b.example.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
     findings = m.analyze()
     assert len(findings) == 0
@@ -475,7 +475,7 @@ async def test_spf_subdomain_inherits_takeover(fs, mock_dispatch_whois, configur
         mock_resolver = configure_mock_resolver(mock_data)
 
         target = "www.example.com"
-        m = BadDNS_spf(target, dns_client=mock_resolver)
+        m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
         findings = None
         if await m.dispatch():
             findings = m.analyze()
@@ -508,7 +508,7 @@ async def test_spf_restricted_tld_no_whois_finding(
         mock_resolver = configure_mock_resolver(mock_data)
 
         target = "dot.gov"
-        m = BadDNS_spf(target, dns_client=mock_resolver)
+        m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
         findings = None
         if await m.dispatch():
             findings = m.analyze()
@@ -528,7 +528,7 @@ async def test_spf_self_referential_include_skipped(configure_mock_resolver):
     mock_resolver = configure_mock_resolver(mock_data)
 
     target = "dot.gov"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
 
     # _ip4spf.dot.gov has base domain dot.gov == target, so WHOIS should be skipped
@@ -544,7 +544,7 @@ async def test_spf_self_referential_subdomain_include_skipped(configure_mock_res
     mock_resolver = configure_mock_resolver(mock_data)
 
     target = "www.cbi.nhtsa.dot.gov"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     assert await m.dispatch()
 
     # _ip4spf.dot.gov is self-referential (base = dot.gov = org domain), should be skipped
@@ -562,9 +562,56 @@ async def test_spf_cloud_target_skipped(configure_mock_resolver):
     mock_data = {}
     mock_resolver = configure_mock_resolver(mock_data)
     target = "bad.com"
-    m = BadDNS_spf(target, dns_client=mock_resolver)
+    m = BadDNS_spf(target, dns_client=mock_resolver, disable_mx_gate=True)
     mock_cc = MagicMock()
     mock_cc.lookup = AsyncMock(return_value=[{"name": "SomeCloud", "tags": ["cloud"]}])
     with patch("baddns.base.CloudCheck", return_value=mock_cc):
         result = await m.dispatch()
     assert result is False
+
+
+# --- MX gate tests ---
+
+
+@pytest.mark.asyncio
+async def test_spf_mx_gate_skips_when_no_mx(configure_mock_resolver):
+    """With the MX gate on (default), SPF skips when neither target nor apex has MX."""
+    mock_data = {"bad.com": {"TXT": ["v=spf1 -all"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_spf("bad.com", dns_client=mock_resolver)
+    assert await m.dispatch() is False
+
+
+@pytest.mark.asyncio
+async def test_spf_mx_gate_runs_with_target_mx(configure_mock_resolver):
+    mock_data = {
+        "sub.bad.com": {"MX": ["mail.bad.com."], "TXT": ["v=spf1 +all"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_spf("sub.bad.com", dns_client=mock_resolver)
+    assert await m.dispatch() is True
+    findings = m.analyze()
+    assert any(f.to_dict()["indicator"] == "+all" for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_spf_mx_gate_runs_with_apex_mx(configure_mock_resolver):
+    mock_data = {
+        "bad.com": {"MX": ["mail.bad.com."]},
+        "sub.bad.com": {"TXT": ["v=spf1 +all"]},
+    }
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_spf("sub.bad.com", dns_client=mock_resolver)
+    assert await m.dispatch() is True
+    findings = m.analyze()
+    assert any(f.to_dict()["indicator"] == "+all" for f in findings)
+
+
+@pytest.mark.asyncio
+async def test_spf_mx_gate_disabled_runs_without_mx(configure_mock_resolver):
+    mock_data = {"bad.com": {"TXT": ["v=spf1 +all"]}}
+    mock_resolver = configure_mock_resolver(mock_data)
+    m = BadDNS_spf("bad.com", dns_client=mock_resolver, disable_mx_gate=True)
+    assert await m.dispatch() is True
+    findings = m.analyze()
+    assert any(f.to_dict()["indicator"] == "+all" for f in findings)


### PR DESCRIPTION
## Summary
- Adds `BadDNS_email_base` (in `baddns/lib/email_base.py`) — shared intermediate base for the email-related modules. Provides `has_email_infra()` (MX check on target, falling back to the registered/apex domain) and `mx_gate_skips()`.
- DMARC and SPF now skip dispatch when neither the target nor its apex has any MX records. MTA-STS still runs — but the orphaned-TXT and policy-MX-mismatch findings are suppressed without MX, while the dangling `mta-sts.*` subdomain takeover and policy-MX WHOIS takeover findings keep running unconditionally (they're real takeover vectors regardless of mail flow).
- New CLI flag `--disable-mx-gate` and matching `disable_mx_gate` kwarg for opt-out (useful for BBOT and explicit "I want everything" runs).
- `get_all_modules()` now walks transitive subclasses and filters on the `name` class attribute, so intermediate bases like `BadDNS_email_base` aren't returned as modules.
- Existing email tests pass `disable_mx_gate=True` to preserve their policy-logic focus; new tests cover the gate (skip without MX, run with subdomain MX, run with apex MX, opt-out via flag, MTA-STS finding-by-finding behavior).