### PR TITLE
Use YARA for batched word matching

### DIFF
--- a/baddns/base.py
+++ b/baddns/base.py
@@ -26,6 +26,7 @@ class BadDNS_base:
         self.parent_class = kwargs.get("parent_class", "self")
         self.cli = cli
         self.disable_negative_signatures = kwargs.get("disable_negative_signatures", False)
+        self.word_matcher = kwargs.get("word_matcher", None)
 
     # hook to allow external manipulation of target assignment
     def set_target(self, target):

--- a/baddns/cli.py
+++ b/baddns/cli.py
@@ -15,6 +15,7 @@ from .lib.errors import BadDNSSignatureException, BadDNSCLIException
 from .lib.logging import setup_logging
 from .lib.loader import load_signatures
 from .lib.findings import CONFIDENCE_LEVELS, SEVERITY_LEVELS
+from .lib.matcher import WordMatcher
 
 from baddns.base import get_all_modules
 
@@ -111,6 +112,7 @@ async def execute_module(
     min_severity=None,
     disable_mx_gate=False,
     disable_negative_signatures=False,
+    word_matcher=None,
 ):
     findings = None
     try:
@@ -123,6 +125,7 @@ async def execute_module(
             direct_mode=direct_mode,
             disable_mx_gate=disable_mx_gate,
             disable_negative_signatures=disable_negative_signatures,
+            word_matcher=word_matcher,
         )
     except BadDNSSignatureException as e:
         log.error(f"Error loading signatures: {e}")
@@ -262,6 +265,7 @@ async def _main():
         log.info(f"Using custom nameservers: [{', '.join(custom_nameservers)}]")
 
     signatures = load_signatures(signatures_dir=custom_signatures)
+    word_matcher = WordMatcher(signatures)
 
     dns_client = Client(custom_nameservers if custom_nameservers else get_system_resolvers())
 
@@ -278,6 +282,7 @@ async def _main():
             min_severity=args.min_severity,
             disable_mx_gate=args.disable_mx_gate,
             disable_negative_signatures=args.disable_negative_signatures,
+            word_matcher=word_matcher,
         )
 
 

--- a/baddns/lib/matcher.py
+++ b/baddns/lib/matcher.py
@@ -76,9 +76,7 @@ class WordMatcher:
                     body_yara_src.append(rule_src)
 
         self._compiled_body = _yara_helper.compile(source="\n".join(body_yara_src)) if body_yara_src else None
-        self._compiled_header = (
-            _yara_helper.compile(source="\n".join(header_yara_src)) if header_yara_src else None
-        )
+        self._compiled_header = _yara_helper.compile(source="\n".join(header_yara_src)) if header_yara_src else None
 
     def match(self, response):
         """Return dict of (sig_idx, matcher_idx) -> bool for all word matchers."""

--- a/baddns/lib/matcher.py
+++ b/baddns/lib/matcher.py
@@ -5,13 +5,108 @@ import yaml
 import logging
 
 from baddns.lib.httpmanager import headers_to_dict
+from baddns.lib.yara_helper import YaraHelper
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 
-# from lib.errors import BadDNSMatcherException
-
 log = logging.getLogger(__name__)
+
+_yara_helper = YaraHelper()
+
+
+class WordMatcher:
+    """Batch all word matchers across signatures into a single YARA ruleset.
+
+    Compile once at signature load time, match once per response body/headers.
+    """
+
+    def __init__(self, signatures):
+        self._body_rules = []
+        self._header_rules = []
+        body_yara_src = []
+        header_yara_src = []
+
+        for sig_idx, sig in enumerate(signatures):
+            mr = sig.signature.get("matcher_rule") or {}
+            for matcher_idx, matcher in enumerate(mr.get("matchers", [])):
+                if matcher.get("type") != "word":
+                    continue
+                part = matcher.get("part", "body").lower()
+                if part in ("host", "cname"):
+                    continue
+
+                words = matcher["words"]
+                condition = matcher.get("condition", "and")
+                negative = matcher.get("negative", False)
+                rule_name = f"sig_{sig_idx}_m_{matcher_idx}"
+
+                yara_strings = []
+                for j, w in enumerate(words):
+                    w_esc = (
+                        w.replace("\\", "\\\\")
+                        .replace('"', '\\"')
+                        .replace("\n", "\\n")
+                        .replace("\r", "\\r")
+                        .replace("\t", "\\t")
+                    )
+                    yara_strings.append(f'        $s{j} = "{w_esc}"')
+
+                yara_cond = "all of them" if condition == "and" else "any of them"
+                rule_src = (
+                    f"rule {rule_name} {{\n"
+                    f"    strings:\n" + "\n".join(yara_strings) + "\n"
+                    f"    condition:\n"
+                    f"        {yara_cond}\n"
+                    f"}}"
+                )
+
+                entry = {
+                    "sig_idx": sig_idx,
+                    "matcher_idx": matcher_idx,
+                    "rule_name": rule_name,
+                    "negative": negative,
+                }
+
+                if part == "header":
+                    self._header_rules.append(entry)
+                    header_yara_src.append(rule_src)
+                else:
+                    self._body_rules.append(entry)
+                    body_yara_src.append(rule_src)
+
+        self._compiled_body = _yara_helper.compile(source="\n".join(body_yara_src)) if body_yara_src else None
+        self._compiled_header = (
+            _yara_helper.compile(source="\n".join(header_yara_src)) if header_yara_src else None
+        )
+
+    def match(self, response):
+        """Return dict of (sig_idx, matcher_idx) -> bool for all word matchers."""
+        results = {}
+
+        if self._compiled_body and response.body:
+            self._eval_rules(self._compiled_body, self._body_rules, response.body, results)
+
+        if self._compiled_header and response.headers:
+            header_text = str(headers_to_dict(response.headers))
+            self._eval_rules(self._compiled_header, self._header_rules, header_text, results)
+
+        return results
+
+    def _eval_rules(self, compiled, rules, text, results):
+        if isinstance(text, str):
+            text_bytes = text.encode("utf-8", errors="replace")
+        else:
+            text_bytes = text
+        matches = compiled.match(data=text_bytes)
+        hit_rules = {m.rule for m in matches}
+
+        for entry in rules:
+            key = (entry["sig_idx"], entry["matcher_idx"])
+            hit = entry["rule_name"] in hit_rules
+            if entry["negative"]:
+                hit = not hit
+            results[key] = hit
 
 
 class Matcher:
@@ -69,15 +164,24 @@ class Matcher:
         elif condition == "or":
             return not any(matches) if negative else any(matches)
 
-    def is_match(self, response):
+    def is_match(self, response, word_results=None, sig_idx=None):
         self.response = response
         matchers_condition = self.rules.get("matchers-condition", "and")
         results = []
         matcher_rule = self.rules.get("matcher_rule", {})
-        for matcher in matcher_rule.get("matchers", []):
+        for matcher_idx, matcher in enumerate(matcher_rule.get("matchers", [])):
             match_type = matcher["type"]
+            if match_type == "word" and word_results is not None and sig_idx is not None:
+                key = (sig_idx, matcher_idx)
+                part = matcher.get("part", "body").lower()
+                if part in ("host", "cname"):
+                    results.append(True)
+                elif key in word_results:
+                    results.append(word_results[key])
+                else:
+                    results.append(False)
+                continue
             match_func = getattr(self, f"_{match_type}", None)
-
             if match_func:
                 result = match_func(matcher)
                 results.append(result)

--- a/baddns/lib/yara_helper.py
+++ b/baddns/lib/yara_helper.py
@@ -5,7 +5,13 @@ class YaraHelper:
     def compile_strings(self, strings, nocase=False):
         yara_strings = []
         for i, s in enumerate(strings):
-            s = s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+            s = (
+                s.replace("\\", "\\\\")
+                .replace('"', '\\"')
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+            )
             yara_string = f'$s{i} = "{s}"'
             if nocase:
                 yara_string += " nocase"

--- a/baddns/lib/yara_helper.py
+++ b/baddns/lib/yara_helper.py
@@ -1,0 +1,39 @@
+import yara
+
+
+class YaraHelper:
+    def compile_strings(self, strings, nocase=False):
+        yara_strings = []
+        for i, s in enumerate(strings):
+            s = s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+            yara_string = f'$s{i} = "{s}"'
+            if nocase:
+                yara_string += " nocase"
+            yara_strings.append(yara_string)
+        yara_strings = "\n        ".join(yara_strings)
+
+        yara_rule = f"""
+rule strings_match
+{{
+    strings:
+        {yara_strings}
+    condition:
+        any of them
+}}
+"""
+        return self.compile(source=yara_rule)
+
+    def compile(self, *args, **kwargs):
+        return yara.compile(*args, **kwargs)
+
+    def match(self, compiled_rules, text):
+        if isinstance(text, str):
+            text = text.encode("utf-8", errors="replace")
+        matches = compiled_rules.match(data=text)
+        matched_strings = []
+        if matches:
+            for match in matches:
+                for string_match in match.strings:
+                    for instance in string_match.instances:
+                        matched_strings.append(instance.matched_data.decode("utf-8", errors="replace"))
+        return matched_strings

--- a/baddns/modules/cname.py
+++ b/baddns/modules/cname.py
@@ -150,7 +150,13 @@ class BadDNS_cname(BadDNS_base):
                 self.target_httpmanager.https_denyredirects_results,
             ]
 
-            for sig in self.signatures:
+            word_results_per_response = {}
+            if self.word_matcher is not None:
+                for hr in http_results:
+                    if hr is not None:
+                        word_results_per_response[id(hr)] = self.word_matcher.match(hr)
+
+            for sig_idx, sig in enumerate(self.signatures):
                 if sig.signature["mode"] == "http":
                     log.debug(f"Trying signature {sig.signature['service_name']}")
                     if len(sig.signature["identifiers"]["cnames"]) > 0:
@@ -196,7 +202,16 @@ class BadDNS_cname(BadDNS_base):
 
                     m = Matcher(sig.signature)
                     log.debug("Checking for HTTP matches")
-                    if any(m.is_match(hr) for hr in http_results if hr is not None):
+                    matched = False
+                    for hr in http_results:
+                        if hr is None:
+                            continue
+                        word_results = word_results_per_response.get(id(hr))
+                        if m.is_match(hr, word_results=word_results, sig_idx=sig_idx):
+                            matched = True
+                            break
+
+                    if matched:
                         log.debug(f"CNAME {self.cname_dnsmanager.target} Vulnerable")
                         log.debug(f"With matcher_rule {sig.signature['matcher_rule']}")
                         findings.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-dateutil>=2.9.0,<3",
     "blasthttp>=0.9.0",
     "cloudcheck>=11,<12",
+    "yara-python>=4.5.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- Adds `baddns/lib/yara_helper.py` — standalone YARA helper for compiling and matching rules
- Adds `WordMatcher` class to `matcher.py` that compiles all 98 word matchers across signatures into a single YARA ruleset at load time
- One YARA `match()` call per HTTP response replaces 98 separate `word in text` substring scans
- `Matcher.is_match()` accepts pre-computed YARA results via `word_results`/`sig_idx` params, falls back to original behavior when not provided (backward compatible)
- `BadDNS_base` accepts optional `word_matcher` kwarg; CLI builds it once after `load_signatures()`
- Adds `yara-python>=4.5.0` dependency
- Corresponding bbot-side change (build `WordMatcher` in `setup()`, pass to modules) will be in a separate bbot PR

Benchmarked at ~1.7x end-to-end speedup. 